### PR TITLE
feat(#5): implement FLV header change detection and recording rotation logic

### DIFF
--- a/internal/processors/buffered_stream_writer.go
+++ b/internal/processors/buffered_stream_writer.go
@@ -43,6 +43,7 @@ func (w *BufferedStreamWriterProcessor) Open(ctx context.Context, log *logrus.En
 	w.file = file
 	w.writer = bufio.NewWriterSize(file, w.bufferSize)
 	w.logger = log.WithField("file", file.Name())
+
 	w.ctx, w.cancel = context.WithCancel(context.Background())
 	w.wait.Add(2)
 	go w.flushPeriodically(w.ctx)

--- a/internal/processors/buffered_stream_writer_test.go
+++ b/internal/processors/buffered_stream_writer_test.go
@@ -48,7 +48,7 @@ func TestBufferedStreamWriter_MemoryLeak(t *testing.T) {
 		t.Fatalf("Failed to generate random data: %v", err)
 	}
 
-	t.Logf("📝 Starting to write %d chunks of %d KB each...", iterations, chunkSize/1024)
+	t.Logf("🚀 Starting to write %d chunks of %d KB each...", iterations, chunkSize/1024)
 	start := time.Now()
 
 	for i := 0; i < iterations; i++ {
@@ -65,7 +65,7 @@ func TestBufferedStreamWriter_MemoryLeak(t *testing.T) {
 	}
 
 	elapsed := time.Since(start)
-	t.Logf("✅ Write phase complete:  %d chunks in %v (%.2f MB/s)",
+	t.Logf("✅ Write phase complete: %d chunks in %v (%.2f MB/s)",
 		iterations, elapsed, float64(iterations*chunkSize)/(1024*1024)/elapsed.Seconds())
 
 	// Read memory after write phase (before GC)
@@ -114,7 +114,7 @@ func TestBufferedStreamWriter_MemoryLeak(t *testing.T) {
 		float64(actualSize)/(1024*1024), float64(expectedSize)/(1024*1024))
 
 	if actualSize != expectedSize {
-		t.Errorf("❌ File size mismatch:  got %d bytes, expected %d bytes", actualSize, expectedSize)
+		t.Errorf("❌ File size mismatch: got %d bytes, expected %d bytes", actualSize, expectedSize)
 	}
 
 	// Memory leak detection thresholds
@@ -127,14 +127,14 @@ func TestBufferedStreamWriter_MemoryLeak(t *testing.T) {
 
 	// Check for memory leaks
 	if retainedAfterGC > maxRetainedAfterGCMB {
-		t.Errorf("⚠️  Possible memory leak:  %.2f MB retained after GC (threshold: %.2f MB)",
+		t.Errorf("⚠️ Possible memory leak: %.2f MB retained after GC (threshold: %.2f MB)",
 			retainedAfterGC, maxRetainedAfterGCMB)
 	} else {
 		t.Logf("✅ Memory after GC is within acceptable range")
 	}
 
 	if retainedAfterClose > maxRetainedAfterCloseMB {
-		t.Errorf("⚠️  Possible memory leak: %.2f MB retained after close (threshold: %.2f MB)",
+		t.Errorf("⚠️ Possible memory leak: %.2f MB retained after close (threshold: %.2f MB)",
 			retainedAfterClose, maxRetainedAfterCloseMB)
 	} else {
 		t.Logf("✅ Memory after close is within acceptable range")
@@ -145,7 +145,7 @@ func TestBufferedStreamWriter_MemoryLeak(t *testing.T) {
 	t.Logf("📈 GC efficiency: %.1f%% of peak growth reclaimed", gcEfficiency)
 
 	if gcEfficiency < 80.0 {
-		t.Errorf("⚠️  Low GC efficiency: only %.1f%% reclaimed (expected > 80%%)", gcEfficiency)
+		t.Errorf("⚠️ Low GC efficiency: only %.1f%% reclaimed (expected > 80%%)", gcEfficiency)
 	}
 }
 
@@ -163,7 +163,7 @@ func TestBufferedStreamWriter_ConcurrentMemoryLeak(t *testing.T) {
 		chunkSize        = 128 * 1024 // 128 KB
 	)
 
-	t.Logf("🔀 Testing %d concurrent writers...", numGoroutines)
+	t.Logf("🔄 Testing %d concurrent writers...", numGoroutines)
 
 	done := make(chan bool, numGoroutines)
 
@@ -214,7 +214,7 @@ func TestBufferedStreamWriter_ConcurrentMemoryLeak(t *testing.T) {
 	t.Logf("  After GC:     %.2f MB (retained: +%.2f MB)", afterGC, afterGC-baseline)
 
 	if (afterGC - baseline) > 15.0 {
-		t.Errorf("⚠️  Possible memory leak in concurrent scenario: %.2f MB retained", afterGC-baseline)
+		t.Errorf("⚠️ Possible memory leak in concurrent scenario: %.2f MB retained", afterGC-baseline)
 	} else {
 		t.Logf("✅ Concurrent memory usage is acceptable")
 	}
@@ -253,7 +253,7 @@ func TestBufferedStreamWriter_LongRunningMemoryProfile(t *testing.T) {
 	memSamples := []float64{}
 	iterations := 0
 
-	t.Logf("⏱️  Running long-duration test for %v.. .", duration)
+	t.Logf("⏱️ Running long-duration test for %v...", duration)
 
 	var m runtime.MemStats
 
@@ -294,7 +294,7 @@ sampleLoop:
 
 		// If memory grows more than 20 MB over time, it's likely a leak
 		if trend > 20.0 {
-			t.Errorf("⚠️  Memory appears to be growing over time: +%.2f MB", trend)
+			t.Errorf("⚠️ Memory appears to be growing over time: +%.2f MB", trend)
 		} else {
 			t.Logf("✅ Memory usage is stable over time")
 		}
@@ -359,7 +359,7 @@ func TestBufferedStreamWriter_NoReturnedDataLeak(t *testing.T) {
 	// Most memory should be from pre-allocated chunks, which is expected
 	// After GC, we should see cleanup
 	if (finalAlloc - baseAlloc) > 10.0 {
-		t.Errorf("⚠️  Possible leak from returned data: %.2f MB retained", finalAlloc-baseAlloc)
+		t.Errorf("⚠️ Possible leak from returned data: %.2f MB retained", finalAlloc-baseAlloc)
 	} else {
 		t.Logf("✅ No leak detected from returned data references")
 	}

--- a/internal/processors/flv_header_split_detector.go
+++ b/internal/processors/flv_header_split_detector.go
@@ -1,0 +1,96 @@
+package processors
+
+import (
+	"context"
+	"errors"
+
+	"github.com/eric2788/bilirec/pkg/flv"
+	"github.com/eric2788/bilirec/pkg/pipeline"
+	"github.com/sirupsen/logrus"
+)
+
+// ErrVideoHeaderChanged is re-exported so callers in this package can match
+// without importing pkg/flv directly.
+var ErrVideoHeaderChanged = flv.ErrVideoHeaderChanged
+
+// flvHeaderSplitDetectorProcessor is a thin pipeline wrapper around
+// flv.HeaderChangeDetector. All parsing logic lives in pkg/flv.
+type flvHeaderSplitDetectorProcessor struct {
+	detector        *flv.HeaderChangeDetector
+	log             *logrus.Entry
+	seedVideoHeader []byte // pre-seeded initial video header tag bytes
+}
+
+// NewFlvHeaderSplitDetector returns a ProcessorInfo that signals pipe rotation
+// via ErrVideoHeaderChanged whenever the AVC sequence header changes.
+func NewFlvHeaderSplitDetector() *pipeline.ProcessorInfo[[]byte] {
+	return pipeline.NewProcessorInfo(
+		"flv-header-split-detector",
+		&flvHeaderSplitDetectorProcessor{
+			detector: flv.NewHeaderChangeDetector(),
+		},
+		pipeline.WithErrorStrategy[[]byte](pipeline.ReturnNextOnError),
+	)
+}
+
+// NewFlvHeaderSplitDetectorSeeded returns a ProcessorInfo pre-seeded with the
+// video sequence header from the prior segment. This ensures the detector can
+// detect changes from the very first sequence header it sees in the new segment
+// rather than treating it as the baseline "first" header.
+// videoHeaderTag must be the full FLV tag bytes as returned in
+// FlvHeaderChangedError.VideoHeaderTag.
+func NewFlvHeaderSplitDetectorSeeded(videoHeaderTag []byte) *pipeline.ProcessorInfo[[]byte] {
+	return pipeline.NewProcessorInfo(
+		"flv-header-split-detector",
+		&flvHeaderSplitDetectorProcessor{
+			detector:        flv.NewHeaderChangeDetector(),
+			seedVideoHeader: videoHeaderTag,
+		},
+		pipeline.WithErrorStrategy[[]byte](pipeline.ReturnNextOnError),
+	)
+}
+
+func (p *flvHeaderSplitDetectorProcessor) Open(ctx context.Context, log *logrus.Entry) error {
+	p.log = log
+	p.detector.Reset()
+	if len(p.seedVideoHeader) > 0 {
+		p.detector.SeedVideoHeader(p.seedVideoHeader)
+	}
+	return nil
+}
+
+func (p *flvHeaderSplitDetectorProcessor) Process(ctx context.Context, log *logrus.Entry, data []byte) ([]byte, error) {
+	err := p.detector.DetectChange(data)
+	if err == nil {
+		return data, nil
+	}
+
+	var headerChanged *flv.FlvHeaderChangedError
+	if errors.As(err, &headerChanged) {
+		log.Infof("🔀 video sequence header changed (SPS/PPS diff), triggering pipe rotation")
+		// Only return bytes after the changed video seq-header tag.
+		// Bytes before the changed tag belong to the old stream config and should
+		// not be replayed into the next segment.
+		if headerChanged.TagEnd >= 0 && headerChanged.TagEnd <= len(data) {
+			after := data[headerChanged.TagEnd:]
+			if len(after) == 0 {
+				return nil, err
+			}
+			// RealtimeFixer expects each tag to be preceded by PrevTagSize (4 bytes).
+			// Since we cut exactly after a tag boundary, inject a synthetic
+			// PrevTagSize to keep parser alignment for replay into next segment.
+			carried := make([]byte, 0, flv.PrevTagSizeBytes+len(after))
+			carried = append(carried, 0, 0, 0, 0)
+			carried = append(carried, after...)
+			return carried, err
+		}
+		return nil, err
+	}
+
+	return data, err
+}
+
+func (p *flvHeaderSplitDetectorProcessor) Close() error {
+	p.detector.Close()
+	return nil
+}

--- a/internal/processors/flv_header_writer.go
+++ b/internal/processors/flv_header_writer.go
@@ -1,0 +1,52 @@
+package processors
+
+import (
+	"context"
+	"sync"
+
+	"github.com/eric2788/bilirec/pkg/flv"
+	"github.com/eric2788/bilirec/pkg/pipeline"
+	"github.com/sirupsen/logrus"
+)
+
+type flvHeaderWriterProcessor struct {
+	writer  *flv.FlvHeaderWriter
+	mu      sync.Mutex
+	written bool
+}
+
+// NewFlvHeaderWriter returns a processor that prepends an FLV file preamble
+// (and optional sequence-header tags) to the very first data chunk of a
+// segment. videoHeaderTag and audioHeaderTag may be nil for segment 0.
+func NewFlvHeaderWriter(videoHeaderTag, audioHeaderTag []byte) *pipeline.ProcessorInfo[[]byte] {
+	return pipeline.NewProcessorInfo(
+		"flv-header-writer",
+		&flvHeaderWriterProcessor{
+			writer: &flv.FlvHeaderWriter{
+				VideoHeaderTag: videoHeaderTag,
+				AudioHeaderTag: audioHeaderTag,
+			},
+		},
+	)
+}
+
+func (p *flvHeaderWriterProcessor) Open(ctx context.Context, log *logrus.Entry) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.written = false
+	return nil
+}
+
+func (p *flvHeaderWriterProcessor) Process(ctx context.Context, log *logrus.Entry, data []byte) ([]byte, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.written {
+		return data, nil
+	}
+	p.written = true
+	return p.writer.Prepend(data), nil
+}
+
+func (p *flvHeaderWriterProcessor) Close() error {
+	return nil
+}

--- a/internal/processors/flv_header_writer_test.go
+++ b/internal/processors/flv_header_writer_test.go
@@ -1,0 +1,62 @@
+package processors_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/eric2788/bilirec/internal/processors"
+	"github.com/eric2788/bilirec/pkg/flv"
+	"github.com/eric2788/bilirec/pkg/pipeline"
+)
+
+func TestFlvHeaderWriterProcessor_BootstrapsHeaders(t *testing.T) {
+	videoTag := flv.NewTagBytes(flv.TagTypeVideo, []byte{0x17, 0x00, 0x00})
+	audioTag := flv.NewTagBytes(flv.TagTypeAudio, []byte{0xaf, 0x00, 0x12})
+
+	pipe := pipeline.New(
+		processors.NewFlvHeaderWriter(videoTag, audioTag),
+	)
+
+	if err := pipe.Open(context.Background()); err != nil {
+		t.Fatalf("open pipeline: %v", err)
+	}
+	defer pipe.Close()
+
+	out, err := pipe.Process(context.Background(), []byte{0x09, 0xaa})
+	if err != nil {
+		t.Fatalf("process: %v", err)
+	}
+
+	want := len(flv.NewFileHeaderBytes()) + len(videoTag) + len(audioTag) + 2
+	if len(out) != want {
+		t.Fatalf("unexpected output length: got %d want %d", len(out), want)
+	}
+
+	// Second process: no header prefix expected
+	second, err := pipe.Process(context.Background(), []byte{0x08})
+	if err != nil {
+		t.Fatalf("second process: %v", err)
+	}
+	if len(second) != 1 {
+		t.Fatalf("expected passthrough after first process, got %d bytes", len(second))
+	}
+}
+
+func TestFlvHeaderWriterProcessor_NoOptionalHeaders(t *testing.T) {
+	pipe := pipeline.New(
+		processors.NewFlvHeaderWriter(nil, nil),
+	)
+	if err := pipe.Open(context.Background()); err != nil {
+		t.Fatalf("open pipeline: %v", err)
+	}
+	defer pipe.Close()
+
+	out, err := pipe.Process(context.Background(), []byte{0xAA, 0xBB})
+	if err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	want := len(flv.NewFileHeaderBytes()) + 2
+	if len(out) != want {
+		t.Fatalf("expected %d bytes (file header + payload), got %d", want, len(out))
+	}
+}

--- a/internal/processors/flv_pipeline_integration_test.go
+++ b/internal/processors/flv_pipeline_integration_test.go
@@ -1,0 +1,620 @@
+package processors_test
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eric2788/bilirec/internal/processors"
+	"github.com/eric2788/bilirec/pkg/flv"
+	"github.com/eric2788/bilirec/pkg/pipeline"
+)
+
+// buildAVCStream constructs a minimal synthetic FLV stream containing:
+//   - FLV file preamble (if withPreamble=true)
+//   - One AVC/H.264 sequence header tag with the given AVCC bytes
+//   - numDataTags dummy inter-frame video tags
+//
+// The resulting bytes can be appended to form a mid-stream continuation by
+// setting withPreamble=false (no FLV file header, tags follow directly).
+func buildAVCStream(avccBytes []byte, numDataTags int, withPreamble bool) []byte {
+	var b []byte
+	if withPreamble {
+		b = append(b, flv.NewFileHeaderBytes()...)
+	}
+
+	// AVC sequence header tag:
+	//   tagData[0] = 0x17: FrameType=1 (keyframe) | CodecID=7 (AVC)
+	//   tagData[1] = 0x00: AVCPacketType=0 (sequence header)
+	//   tagData[2..4] = composition time offset = 0
+	//   tagData[5..] = AVCDecoderConfigurationRecord (avccBytes)
+	seqData := make([]byte, 0, 5+len(avccBytes))
+	seqData = append(seqData, 0x17, 0x00, 0x00, 0x00, 0x00)
+	seqData = append(seqData, avccBytes...)
+	b = append(b, flv.NewTagBytes(flv.TagTypeVideo, seqData)...)
+
+	// Dummy inter-frame video tags (not seq headers, won't trigger rotation)
+	frame := make([]byte, 6+50)
+	frame[0] = 0x27 // FrameType=2 (inter) | CodecID=7 (AVC)
+	frame[1] = 0x01 // AVCPacketType=1 (NALU)
+	for i := 0; i < numDataTags; i++ {
+		b = append(b, flv.NewTagBytes(flv.TagTypeVideo, frame)...)
+	}
+	return b
+}
+
+// avcc360p and avcc720p are minimal fake AVCDecoderConfigurationRecords that
+// differ in profile/level bytes, ensuring the detector sees a header change.
+var (
+	avcc360p = []byte{0x01, 0x42, 0x00, 0x1f, 0xff, 0xe1, 0x00, 0x04, 0x67, 0x42, 0x00, 0x1f}
+	avcc720p = []byte{0x01, 0x64, 0x00, 0x29, 0xff, 0xe1, 0x00, 0x04, 0x67, 0x64, 0x00, 0x29}
+)
+
+func buildContinuousHTTPFLVStreamFromFixtures(fixtureNames []string) ([]byte, [][]byte, error) {
+	fixtures := make([][]byte, 0, len(fixtureNames))
+	for _, name := range fixtureNames {
+		data, err := os.ReadFile(filepath.Join("testdata", name))
+		if err != nil {
+			return nil, nil, err
+		}
+		fixtures = append(fixtures, data)
+	}
+
+	preamble := flv.FlvHeaderSize + flv.PrevTagSizeBytes
+	for i, data := range fixtures {
+		if len(data) <= preamble {
+			return nil, nil, errors.New("fixture too small: " + fixtureNames[i])
+		}
+	}
+
+	stream := make([]byte, 0, len(fixtures[0]))
+	stream = append(stream, fixtures[0]...)
+	lastTs := maxTagTimestamp(fixtures[0][preamble:])
+
+	for i := 1; i < len(fixtures); i++ {
+		var err error
+		stream, err = appendNormalizedContinuation(stream, fixtures[i][preamble:], &lastTs)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return stream, fixtures, nil
+}
+
+func maxTagTimestamp(payload []byte) int64 {
+	var maxTs int64
+	offset := 0
+	for offset+flv.TagHeaderSize <= len(payload) {
+		dataSize := int(payload[offset+1])<<16 | int(payload[offset+2])<<8 | int(payload[offset+3])
+		tagEnd := offset + flv.TagHeaderSize + dataSize
+		fullEnd := tagEnd + flv.PrevTagSizeBytes
+		if fullEnd > len(payload) {
+			break
+		}
+		ts := int64(uint32(payload[offset+7])<<24 | uint32(payload[offset+4])<<16 | uint32(payload[offset+5])<<8 | uint32(payload[offset+6]))
+		if ts > maxTs {
+			maxTs = ts
+		}
+		offset = fullEnd
+	}
+	return maxTs
+}
+
+func appendNormalizedContinuation(dst []byte, payload []byte, lastTs *int64) ([]byte, error) {
+	minTs := int64(-1)
+	offset := 0
+	for offset+flv.TagHeaderSize <= len(payload) {
+		tagType := payload[offset]
+		dataSize := int(payload[offset+1])<<16 | int(payload[offset+2])<<8 | int(payload[offset+3])
+		tagEnd := offset + flv.TagHeaderSize + dataSize
+		fullEnd := tagEnd + flv.PrevTagSizeBytes
+		if fullEnd > len(payload) {
+			break
+		}
+		if tagType != flv.TagTypeScript {
+			ts := int64(uint32(payload[offset+7])<<24 | uint32(payload[offset+4])<<16 | uint32(payload[offset+5])<<8 | uint32(payload[offset+6]))
+			if minTs < 0 || ts < minTs {
+				minTs = ts
+			}
+		}
+		offset = fullEnd
+	}
+
+	delta := int64(0)
+	if minTs >= 0 && minTs <= *lastTs {
+		delta = (*lastTs + 1) - minTs
+	}
+
+	offset = 0
+	for offset+flv.TagHeaderSize <= len(payload) {
+		tagType := payload[offset]
+		dataSize := int(payload[offset+1])<<16 | int(payload[offset+2])<<8 | int(payload[offset+3])
+		tagEnd := offset + flv.TagHeaderSize + dataSize
+		fullEnd := tagEnd + flv.PrevTagSizeBytes
+		if fullEnd > len(payload) {
+			break
+		}
+		if tagType != flv.TagTypeScript {
+			ts := int64(uint32(payload[offset+7])<<24|uint32(payload[offset+4])<<16|uint32(payload[offset+5])<<8|uint32(payload[offset+6])) + delta
+			if ts < 0 {
+				ts = 0
+			}
+			if ts > 0xFFFFFFFF {
+				ts = 0xFFFFFFFF
+			}
+
+			head := make([]byte, flv.TagHeaderSize)
+			copy(head, payload[offset:offset+flv.TagHeaderSize])
+			head[4] = byte(ts >> 16)
+			head[5] = byte(ts >> 8)
+			head[6] = byte(ts)
+			head[7] = byte(ts >> 24)
+
+			dst = append(dst, head...)
+			dst = append(dst, payload[offset+flv.TagHeaderSize:tagEnd]...)
+
+			prev := make([]byte, 4)
+			binary.BigEndian.PutUint32(prev, uint32(flv.TagHeaderSize+dataSize))
+			dst = append(dst, prev...)
+
+			if ts > *lastTs {
+				*lastTs = ts
+			}
+		}
+		offset = fullEnd
+	}
+
+	return dst, nil
+}
+
+// TestFlvPipeline_ResolutionChangeRotation feeds a synthetic HTTP-FLV stream
+// that switches from 360p to 720p AVC parameters mid-stream through the full
+// processor pipeline and verifies that exactly one rotation occurs and that
+// both output segments begin with a valid FLV file header.
+func TestFlvPipeline_ResolutionChangeRotation(t *testing.T) {
+	// Build a simulated HTTP-FLV stream:
+	//   [full 360p FLV file] + [720p continuation without FLV preamble]
+	stream360 := buildAVCStream(avcc360p, 20, true)  // with FLV header
+	stream720 := buildAVCStream(avcc720p, 20, false) // mid-stream, no header
+	stream := append(stream360, stream720...)
+
+	tmpDir := t.TempDir()
+	outFile := func(seg int) string {
+		return filepath.Join(tmpDir, "seg"+string(rune('0'+seg))+".flv")
+	}
+	sharedFixer := flv.NewRealtimeFixer()
+	defer sharedFixer.Close()
+
+	openPipe := func(videoHdr, audioHdr []byte, outPath string) *pipeline.Pipe[[]byte] {
+		p := pipeline.New(
+			processors.NewFlvStreamFixerWithFixer(sharedFixer),
+			processors.NewFlvHeaderSplitDetector(),
+			processors.NewFlvHeaderWriter(videoHdr, audioHdr),
+			processors.NewBufferedStreamWriter(outPath, 4*1024*1024),
+		)
+		if err := p.Open(context.Background()); err != nil {
+			t.Fatalf("open pipeline: %v", err)
+		}
+		return p
+	}
+
+	const chunkSize = 512 // small chunks to stress-test buffer boundaries
+	segment := 0
+	var videoHdr, audioHdr []byte
+	pipe := openPipe(nil, nil, outFile(segment))
+	rotations := 0
+
+	for offset := 0; offset < len(stream); {
+		end := offset + chunkSize
+		if end > len(stream) {
+			end = len(stream)
+		}
+		_, procErr := pipe.Process(context.Background(), stream[offset:end])
+		offset = end
+
+		if procErr != nil {
+			var headerChanged *flv.FlvHeaderChangedError
+			if errors.As(procErr, &headerChanged) {
+				t.Logf("rotation %d triggered at stream offset %d", rotations+1, offset)
+				pipe.Close()
+				videoHdr = headerChanged.VideoHeaderTag
+				audioHdr = headerChanged.AudioHeaderTag
+				rotations++
+				segment++
+				pipe = openPipe(videoHdr, audioHdr, outFile(segment))
+				continue
+			}
+			t.Fatalf("unexpected pipeline error at offset %d: %v", offset, procErr)
+		}
+	}
+	pipe.Close()
+
+	if rotations != 1 {
+		t.Fatalf("expected exactly 1 rotation, got %d", rotations)
+	}
+
+	// Verify both output segments: non-trivial size and valid FLV magic.
+	for seg := 0; seg <= 1; seg++ {
+		path := outFile(seg)
+		st, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat seg%d: %v", seg, err)
+		}
+		if st.Size() < int64(flv.FlvHeaderSize+flv.PrevTagSizeBytes) {
+			t.Fatalf("seg%d.flv too small: %d bytes", seg, st.Size())
+		}
+		header := make([]byte, 3)
+		f, err := os.Open(path)
+		if err != nil {
+			t.Fatalf("open seg%d: %v", seg, err)
+		}
+		_, err = io.ReadFull(f, header)
+		f.Close()
+		if err != nil {
+			t.Fatalf("read seg%d header: %v", seg, err)
+		}
+		if header[0] != 'F' || header[1] != 'L' || header[2] != 'V' {
+			t.Fatalf("seg%d.flv does not start with FLV magic, got %v", seg, header)
+		}
+		t.Logf("seg%d.flv: %d bytes, valid FLV header ✓", seg, st.Size())
+	}
+
+	// seg1 must carry the 720p AVC sequence header injected by FlvHeaderWriter.
+	if len(videoHdr) == 0 {
+		t.Fatal("expected non-empty VideoHeaderTag after rotation")
+	}
+	t.Logf("VideoHeaderTag: %d bytes, AudioHeaderTag: %d bytes", len(videoHdr), len(audioHdr))
+}
+
+// TestFlvPipeline_ResolutionChangeRotation_RealFixtures uses local real-world
+// fixtures in testdata/ to simulate an HTTP-FLV mid-stream resolution change:
+//
+//	[A.flv full stream] + [B.flv without FLV preamble].
+//
+// This test is intentionally optional: if fixtures are missing in CI, it skips.
+func TestFlvPipeline_ResolutionChangeRotation_RealFixtures(t *testing.T) {
+	fixtureNames := []string{"A.flv", "B.flv", "C.flv", "D.flv"}
+	stream, _, err := buildContinuousHTTPFLVStreamFromFixtures(fixtureNames)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Skipf("real fixtures not found: %v", err)
+		}
+		t.Fatalf("build continuous stream from fixtures: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	outFile := func(seg int) string {
+		return filepath.Join(tmpDir, "real-seg"+string(rune('0'+seg))+".flv")
+	}
+	sharedFixer := flv.NewRealtimeFixer()
+	defer sharedFixer.Close()
+
+	openPipe := func(videoHdr, audioHdr []byte, outPath string) *pipeline.Pipe[[]byte] {
+		var splitDetector *pipeline.ProcessorInfo[[]byte]
+		if len(videoHdr) > 0 {
+			splitDetector = processors.NewFlvHeaderSplitDetectorSeeded(videoHdr)
+		} else {
+			splitDetector = processors.NewFlvHeaderSplitDetector()
+		}
+		p := pipeline.New(
+			processors.NewFlvStreamFixerWithFixer(sharedFixer),
+			splitDetector,
+			processors.NewFlvHeaderWriter(videoHdr, audioHdr),
+			processors.NewBufferedStreamWriter(outPath, 4*1024*1024),
+		)
+		if err := p.Open(context.Background()); err != nil {
+			t.Fatalf("open pipeline: %v", err)
+		}
+		return p
+	}
+
+	const chunkSize = 32 * 1024
+	segment := 0
+	rotations := 0
+	var videoHdr, audioHdr []byte
+	var pendingData []byte
+	pipe := openPipe(nil, nil, outFile(segment))
+
+	for offset := 0; offset < len(stream); {
+		if len(pendingData) > 0 {
+			if _, perr := pipe.Process(context.Background(), pendingData); perr != nil {
+				t.Fatalf("failed to replay pending split chunk: %v", perr)
+			}
+			pendingData = nil
+		}
+
+		end := offset + chunkSize
+		if end > len(stream) {
+			end = len(stream)
+		}
+
+		result, procErr := pipe.Process(context.Background(), stream[offset:end])
+		offset = end
+
+		if procErr != nil {
+			var headerChanged *flv.FlvHeaderChangedError
+			if errors.As(procErr, &headerChanged) {
+				t.Logf("real fixture rotation %d at stream offset %d", rotations+1, offset)
+				pipe.Close()
+				videoHdr = headerChanged.VideoHeaderTag
+				audioHdr = headerChanged.AudioHeaderTag
+				pendingData = result
+				rotations++
+				segment++
+				pipe = openPipe(videoHdr, audioHdr, outFile(segment))
+				continue
+			}
+			t.Fatalf("unexpected pipeline error at offset %d: %v", offset, procErr)
+		}
+	}
+	pipe.Close()
+
+	if rotations < 1 {
+		t.Fatalf("expected at least 1 rotation from real fixtures, got %d", rotations)
+	}
+
+	for seg := 0; seg <= segment; seg++ {
+		path := outFile(seg)
+		st, statErr := os.Stat(path)
+		if statErr != nil {
+			t.Fatalf("stat real-seg%d: %v", seg, statErr)
+		}
+		if st.Size() < int64(flv.FlvHeaderSize+flv.PrevTagSizeBytes) {
+			t.Fatalf("real-seg%d.flv too small: %d bytes", seg, st.Size())
+		}
+
+		header := make([]byte, 3)
+		f, openErr := os.Open(path)
+		if openErr != nil {
+			t.Fatalf("open real-seg%d: %v", seg, openErr)
+		}
+		_, readErr := io.ReadFull(f, header)
+		f.Close()
+		if readErr != nil {
+			t.Fatalf("read real-seg%d header: %v", seg, readErr)
+		}
+		if header[0] != 'F' || header[1] != 'L' || header[2] != 'V' {
+			t.Fatalf("real-seg%d.flv missing FLV magic: %v", seg, header)
+		}
+	}
+
+	if len(videoHdr) == 0 {
+		t.Fatal("expected non-empty VideoHeaderTag after real-fixture rotation")
+	}
+}
+
+// TestFlvPipeline_GenerateBeforeAfterArtifacts writes concrete FLV artifacts
+// for manual visual comparison (Before/After) using real fixtures.
+//
+// Enable by setting BILIREC_WRITE_SIM_ARTIFACTS=1.
+// Output directory: internal/processors/testdata/simulated
+func TestFlvPipeline_GenerateBeforeAfterArtifacts(t *testing.T) {
+	if os.Getenv("BILIREC_WRITE_SIM_ARTIFACTS") != "1" {
+		t.Skip("set BILIREC_WRITE_SIM_ARTIFACTS=1 to generate before/after FLV artifacts")
+	}
+
+	fixtureNames := []string{"A.flv", "B.flv", "C.flv", "D.flv"}
+	mixed, fixtures, err := buildContinuousHTTPFLVStreamFromFixtures(fixtureNames)
+	if err != nil {
+		t.Fatalf("build continuous stream from fixtures: %v", err)
+	}
+	preamble := flv.FlvHeaderSize + flv.PrevTagSizeBytes
+
+	outDir := filepath.Join("testdata", "simulated")
+	if err := os.MkdirAll(outDir, 0755); err != nil {
+		t.Fatalf("mkdir simulated output: %v", err)
+	}
+
+	// 1) headless continuation chunk (no FLV file header)
+	headless := fixtures[1][preamble:]
+	headlessPath := filepath.Join(outDir, "before_headless_continuation.flv")
+	if err := os.WriteFile(headlessPath, headless, 0644); err != nil {
+		t.Fatalf("write headless artifact: %v", err)
+	}
+
+	// 2) single mixed file without split (commonly leads to mosaic/artifacts)
+	// built from normalized A+B+C+D continuation stream.
+	mixedPath := filepath.Join(outDir, "before_mixed_no_split.flv")
+	if err := os.WriteFile(mixedPath, mixed, 0644); err != nil {
+		t.Fatalf("write mixed artifact: %v", err)
+	}
+
+	// 2.5) bilibili-like HTTP-FLV artifact from the COMBINED stream:
+	// keep FLV preamble, but remove script metadata tags so duration is not fixed.
+	filterOutScriptTags := func(payload []byte) []byte {
+		out := make([]byte, 0, len(payload))
+		offset := 0
+		for offset+flv.TagHeaderSize <= len(payload) {
+			tagType := payload[offset]
+			dataSize := int(payload[offset+1])<<16 | int(payload[offset+2])<<8 | int(payload[offset+3])
+			tagEnd := offset + flv.TagHeaderSize + dataSize
+			fullEnd := tagEnd + flv.PrevTagSizeBytes
+			if fullEnd > len(payload) {
+				out = append(out, payload[offset:]...)
+				break
+			}
+			if tagType != flv.TagTypeScript {
+				out = append(out, payload[offset:fullEnd]...)
+			}
+			offset = fullEnd
+		}
+		if offset < len(payload) {
+			out = append(out, payload[offset:]...)
+		}
+		return out
+	}
+	httpFlvPayload := filterOutScriptTags(mixed[preamble:])
+	httpFlvLike := make([]byte, 0, preamble+len(httpFlvPayload))
+	httpFlvLike = append(httpFlvLike, flv.NewFileHeaderBytes()...)
+	httpFlvLike = append(httpFlvLike, httpFlvPayload...)
+	httpFlvLikePath := filepath.Join(outDir, "before_httpflv_like_no_duration.flv")
+	if err := os.WriteFile(httpFlvLikePath, httpFlvLike, 0644); err != nil {
+		t.Fatalf("write http-flv-like artifact: %v", err)
+	}
+	if len(httpFlvLike) <= len(fixtures[0]) {
+		t.Fatalf("http-flv-like artifact is not combined A+B+C+D: got %d, A=%d", len(httpFlvLike), len(fixtures[0]))
+	}
+	if len(httpFlvLike) >= len(mixed) {
+		t.Fatalf("http-flv-like artifact did not remove metadata as expected: http=%d mixed=%d", len(httpFlvLike), len(mixed))
+	}
+	firstTagType := httpFlvLike[preamble]
+	if firstTagType == flv.TagTypeScript {
+		t.Fatalf("http-flv-like artifact still starts with script metadata tag")
+	}
+
+	// 3) split by pipeline into after_segment_*.flv
+	outFile := func(seg int) string {
+		return filepath.Join(outDir, "after_segment_"+string(rune('0'+seg))+".flv")
+	}
+	sharedFixer := flv.NewRealtimeFixer()
+	defer sharedFixer.Close()
+
+	openPipe := func(videoHdr, audioHdr []byte, outPath string) *pipeline.Pipe[[]byte] {
+		var splitDetector *pipeline.ProcessorInfo[[]byte]
+		if len(videoHdr) > 0 {
+			splitDetector = processors.NewFlvHeaderSplitDetectorSeeded(videoHdr)
+		} else {
+			splitDetector = processors.NewFlvHeaderSplitDetector()
+		}
+		p := pipeline.New(
+			processors.NewFlvStreamFixerWithFixer(sharedFixer),
+			splitDetector,
+			processors.NewFlvHeaderWriter(videoHdr, audioHdr),
+			processors.NewBufferedStreamWriter(outPath, 4*1024*1024),
+		)
+		if openErr := p.Open(context.Background()); openErr != nil {
+			t.Fatalf("open pipeline: %v", openErr)
+		}
+		return p
+	}
+
+	segment := 0
+	rotations := 0
+	var videoHdr, audioHdr []byte
+	pipe := openPipe(nil, nil, outFile(segment))
+	const chunkSize = 32 * 1024
+
+	for offset := 0; offset < len(mixed); {
+		end := offset + chunkSize
+		if end > len(mixed) {
+			end = len(mixed)
+		}
+
+		_, procErr := pipe.Process(context.Background(), mixed[offset:end])
+		offset = end
+
+		if procErr != nil {
+			var headerChanged *flv.FlvHeaderChangedError
+			if errors.As(procErr, &headerChanged) {
+				pipe.Close()
+				videoHdr = headerChanged.VideoHeaderTag
+				audioHdr = headerChanged.AudioHeaderTag
+				// Reset fixer's timestamp state for new segment so timestamps start from 0
+				sharedFixer.ResetTimestampStore()
+				rotations++
+				segment++
+				pipe = openPipe(videoHdr, audioHdr, outFile(segment))
+				continue
+			}
+			t.Fatalf("unexpected pipeline error at offset %d: %v", offset, procErr)
+		}
+	}
+	pipe.Close()
+
+	// 4) realtime-fixer only pipeline (NO header split detector):
+	// this simulates old behavior where stream continues across resolution change
+	// in a single output file.
+	noSplitPath := filepath.Join(outDir, "before_realtime_fixer_no_split.flv")
+	noSplitPipe := pipeline.New(
+		processors.NewFlvStreamFixer(),
+		processors.NewFlvHeaderWriter(nil, nil),
+		processors.NewBufferedStreamWriter(noSplitPath, 4*1024*1024),
+	)
+	if openErr := noSplitPipe.Open(context.Background()); openErr != nil {
+		t.Fatalf("open no-split pipeline: %v", openErr)
+	}
+	for offset := 0; offset < len(mixed); {
+		end := offset + chunkSize
+		if end > len(mixed) {
+			end = len(mixed)
+		}
+		if _, procErr := noSplitPipe.Process(context.Background(), mixed[offset:end]); procErr != nil {
+			noSplitPipe.Close()
+			t.Fatalf("no-split pipeline error at offset %d: %v", offset, procErr)
+		}
+		offset = end
+	}
+	noSplitPipe.Close()
+
+	if st, statErr := os.Stat(noSplitPath); statErr != nil {
+		t.Fatalf("stat no-split artifact: %v", statErr)
+	} else if st.Size() <= int64(flv.FlvHeaderSize+flv.PrevTagSizeBytes) {
+		t.Fatalf("no-split artifact too small: %d", st.Size())
+	}
+
+	t.Logf("generated artifacts at %s", outDir)
+	t.Logf("headless: %s", headlessPath)
+	t.Logf("http-flv-like no-duration: %s", httpFlvLikePath)
+	t.Logf("before mixed (no split): %s", mixedPath)
+	t.Logf("before realtime-fixer no split: %s", noSplitPath)
+	for i := 0; i <= segment; i++ {
+		t.Logf("after segment %d: %s", i, outFile(i))
+	}
+	t.Logf("pipeline rotations: %d", rotations)
+}
+
+// TestFlvPipeline_RealtimeFixerNoSplit_RealFixtures simulates pipeline behavior
+// when using realtime fixer but NOT using the header split detector.
+func TestFlvPipeline_RealtimeFixerNoSplit_RealFixtures(t *testing.T) {
+	fixtureNames := []string{"A.flv", "B.flv", "C.flv", "D.flv"}
+	stream, _, err := buildContinuousHTTPFLVStreamFromFixtures(fixtureNames)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Skipf("real fixtures not found: %v", err)
+		}
+		t.Fatalf("build continuous stream from fixtures: %v", err)
+	}
+
+	outPath := filepath.Join(t.TempDir(), "realtime_fixer_no_split.flv")
+	pipe := pipeline.New(
+		processors.NewFlvStreamFixer(),
+		processors.NewFlvHeaderWriter(nil, nil),
+		processors.NewBufferedStreamWriter(outPath, 4*1024*1024),
+	)
+	if err := pipe.Open(context.Background()); err != nil {
+		t.Fatalf("open pipeline: %v", err)
+	}
+
+	const chunkSize = 32 * 1024
+	for offset := 0; offset < len(stream); {
+		end := offset + chunkSize
+		if end > len(stream) {
+			end = len(stream)
+		}
+		if _, err := pipe.Process(context.Background(), stream[offset:end]); err != nil {
+			pipe.Close()
+			t.Fatalf("no-split process failed at offset %d: %v", offset, err)
+		}
+		offset = end
+	}
+	pipe.Close()
+
+	header := make([]byte, 3)
+	f, err := os.Open(outPath)
+	if err != nil {
+		t.Fatalf("open output: %v", err)
+	}
+	_, err = io.ReadFull(f, header)
+	f.Close()
+	if err != nil {
+		t.Fatalf("read output header: %v", err)
+	}
+	if header[0] != 'F' || header[1] != 'L' || header[2] != 'V' {
+		t.Fatalf("no-split output missing FLV magic: %v", header)
+	}
+}

--- a/internal/processors/flv_stream_fixer.go
+++ b/internal/processors/flv_stream_fixer.go
@@ -13,11 +13,26 @@ var ErrNotFlvFile = flv.ErrNotFlvFile
 type FlvStreamFixerProcessor struct {
 	fixer *flv.RealtimeFixer
 	log   *logrus.Entry
+	own   bool
 }
 
 func NewFlvStreamFixer() *pipeline.ProcessorInfo[[]byte] {
 	ffp := &FlvStreamFixerProcessor{
 		fixer: flv.NewRealtimeFixer(),
+		own:   true,
+	}
+	return pipeline.NewProcessorInfo(
+		"flv-fixer",
+		ffp,
+	)
+}
+
+// NewFlvStreamFixerWithFixer reuses an external RealtimeFixer instance.
+// The processor will not close/reset this fixer in Close().
+func NewFlvStreamFixerWithFixer(fixer *flv.RealtimeFixer) *pipeline.ProcessorInfo[[]byte] {
+	ffp := &FlvStreamFixerProcessor{
+		fixer: fixer,
+		own:   false,
 	}
 	return pipeline.NewProcessorInfo(
 		"flv-fixer",
@@ -35,8 +50,10 @@ func (p *FlvStreamFixerProcessor) Process(ctx context.Context, log *logrus.Entry
 }
 
 func (p *FlvStreamFixerProcessor) Close() error {
-	defer p.fixer.Close()
 	dups, size, capacity := p.fixer.GetDedupStats()
 	p.log.Infof("🗂️ Dedup Stats: %d duplicates detected, cache size: %d/%d", dups, size, capacity)
+	if p.own {
+		p.fixer.Close()
+	}
 	return nil
 }

--- a/internal/services/recorder/info.go
+++ b/internal/services/recorder/info.go
@@ -1,0 +1,31 @@
+package recorder
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/eric2788/bilirec/internal/modules/bilibili"
+)
+
+type Info struct {
+	status     atomic.Pointer[RecordStatus]
+	bytesRead  atomic.Uint64
+	startTime  time.Time
+	outputPath atomic.Value // string
+
+	cancel context.CancelFunc
+	room   *bilibili.LiveRoomInfoDetail
+}
+
+func (r *Info) SetOutputPath(path string) {
+	r.outputPath.Store(path) // must always store string
+}
+
+func (r *Info) OutputPath() string {
+	v := r.outputPath.Load()
+	if v == nil {
+		return ""
+	}
+	return v.(string)
+}

--- a/internal/services/recorder/recorder.go
+++ b/internal/services/recorder/recorder.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
-	"sync/atomic"
 	"time"
 
 	"github.com/eric2788/bilirec/internal/modules/bilibili"
@@ -17,6 +16,7 @@ import (
 	"github.com/eric2788/bilirec/internal/services/convert"
 	"github.com/eric2788/bilirec/internal/services/stream"
 	"github.com/eric2788/bilirec/pkg/ds"
+	"github.com/eric2788/bilirec/pkg/flv"
 	"github.com/eric2788/bilirec/pkg/pipeline"
 	"github.com/eric2788/bilirec/utils"
 	"github.com/puzpuzpuz/xsync/v4"
@@ -45,22 +45,13 @@ var ErrRoomBanned = errors.New("the room is banned")
 var ErrRoomEncrypted = errors.New("the room is encrypted")
 var ErrInsufficientDiskSpace = errors.New("insufficient disk space")
 
-type Recorder struct {
-	status     atomic.Pointer[RecordStatus]
-	bytesRead  atomic.Uint64
-	startTime  time.Time
-	outputPath string
-
-	cancel context.CancelFunc
-}
-
 type Service struct {
-	st            *stream.Service
-	cv            *convert.Service
-	bilic         *bilibili.Client
-	recording     *xsync.Map[int, *Recorder]
-	writtingFiles ds.Set[string]
-	pipes         *xsync.Map[int, *pipeline.Pipe[[]byte]]
+	st           *stream.Service
+	cv           *convert.Service
+	bilic        *bilibili.Client
+	recording    *xsync.Map[int, *Info]
+	writingFiles ds.Set[string]
+	pipes        *xsync.Map[int, *pipeline.Pipe[[]byte]]
 
 	cfg *config.Config
 	ctx context.Context
@@ -77,14 +68,14 @@ func NewService(
 	ctx, cancel := context.WithCancel(context.Background())
 
 	s := &Service{
-		st:            st,
-		cv:            cv,
-		bilic:         bilic,
-		recording:     xsync.NewMap[int, *Recorder](),
-		writtingFiles: ds.NewSyncedSet[string](),
-		pipes:         xsync.NewMap[int, *pipeline.Pipe[[]byte]](),
-		cfg:           cfg,
-		ctx:           ctx,
+		st:           st,
+		cv:           cv,
+		bilic:        bilic,
+		recording:    xsync.NewMap[int, *Info](),
+		writingFiles: ds.NewSyncedSet[string](),
+		pipes:        xsync.NewMap[int, *pipeline.Pipe[[]byte]](),
+		cfg:          cfg,
+		ctx:          ctx,
 	}
 
 	cv.SetActiveRecordingsGetter(s.recording.Size)
@@ -139,12 +130,6 @@ func (r *Service) Start(roomId int) error {
 	}
 
 	now := time.Now()
-
-	outputPath, err := r.prepareFilePath(roomInfo, now)
-	if err != nil {
-		return fmt.Errorf("cannot prepare file path: %v", err)
-	}
-
 	ctx, cancel := context.WithCancel(r.ctx)
 
 	// retry mechanism
@@ -161,14 +146,12 @@ func (r *Service) Start(roomId int) error {
 		}
 
 		// initialize Recorder info
-		info := &Recorder{
-			cancel:     cancel,
-			startTime:  now,
-			outputPath: outputPath,
+		info := &Info{
+			cancel:    cancel,
+			startTime: now,
+			room:      roomInfo,
 		}
-		info.status.Store(recordingPtr)
-		r.writtingFiles.Add(filepath.Base(outputPath))
-
+		info.SetOutputPath("") // initialize output path to empty string to avoid potential nil pointer dereference in finalize()
 		return r.prepare(roomId, ch, ctx, info)
 	}
 	cancel()
@@ -195,61 +178,117 @@ func (r *Service) Stop(roomId int) bool {
 	return hasRecording
 }
 
-func (r *Service) prepare(roomId int, ch <-chan []byte, ctx context.Context, info *Recorder) error {
+func (r *Service) prepare(roomId int, ch <-chan []byte, ctx context.Context, info *Info) error {
 
-	pipe := pipeline.New(
-		// fix FLV stream
-		processors.NewFlvStreamFixer(),
-		// write to file with buffered writer
-		// flushes every 5 seconds then writes to disk
-		processors.NewBufferedStreamWriter(info.outputPath, config.ReadOnly.LiveStreamWriterBufferSize()),
-	)
-
-	startCtx, startCancel := context.WithTimeout(ctx, 10*time.Second)
-	if err := pipe.Open(startCtx); err != nil {
-		startCancel()
-		return fmt.Errorf("cannot open pipeline: %v", err)
-	}
-	startCancel()
-
+	info.status.Store(recordingPtr)
 	r.recording.Store(roomId, info)
-	r.pipes.Store(roomId, pipe)
 
-	go r.rev(roomId, ch, info, pipe)
+	go func() {
+		defer r.recover(roomId)
+		defer info.cancel()
+		err := r.rotate(roomId, ch, info, ctx)
+		if err != nil {
+			logger.Errorf("error rotating recording: %v", err)
+		}
+	}()
+
 	go r.checkRecordingDurationPeriodically(roomId, ctx)
 	return nil
 }
 
-func (r *Service) rev(roomId int, ch <-chan []byte, info *Recorder, pipe *pipeline.Pipe[[]byte]) {
+func (r *Service) rotate(roomId int, ch <-chan []byte, info *Info, ctx context.Context) error {
 	l := logger.WithField("room", roomId)
-	defer r.recover(roomId)
-	defer func() {
-		pipe.Close()
-		go r.finalize(roomId, info)
-	}()
-	for data := range ch {
+	segment := 0
+	// Keep one fixer instance across rotation so partial/raw alignment state is preserved.
+	sharedFixer := flv.NewRealtimeFixer()
+	defer sharedFixer.Close()
+	// videoHdr and audioHdr are nil for segment 0; populated from FlvHeaderChangedError on rotation.
+	var videoHdr, audioHdr []byte
+	for {
 
-		info.bytesRead.Add(uint64(len(data)))
-		result, err := pipe.Process(r.ctx, data)
-		r.st.Flush(data)
-		r.st.Flush(result)
-
+		outputPath, err := r.rotateFilePath(info, segment)
 		if err != nil {
-			l.Errorf("error writing data to file: %v", err)
-			if err == processors.ErrNotFlvFile {
-				l.Warn("received FLV validation errors, stream may be unstable")
+			return fmt.Errorf("cannot prepare file path: %v", err)
+		} else {
+			info.SetOutputPath(outputPath)
+		}
+
+		pipe := pipeline.New(
+			// fix FLV stream (shared fixer across segments)
+			processors.NewFlvStreamFixerWithFixer(sharedFixer),
+			// detect FLV header changes (e.g. due to stream quality changes) and trigger pipe rotation
+			processors.NewFlvHeaderSplitDetectorSeeded(videoHdr),
+			// emit FLV file header once per segment, with optional video/audio sequence-header tags
+			processors.NewFlvHeaderWriter(videoHdr, audioHdr),
+			// write to file with buffered writer, flushes every 5 seconds then writes to disk
+			processors.NewBufferedStreamWriter(info.OutputPath(), config.ReadOnly.LiveStreamWriterBufferSize()),
+		)
+
+		startCtx, startCancel := context.WithTimeout(ctx, 10*time.Second)
+		if err := pipe.Open(startCtx); err != nil {
+			startCancel()
+			return fmt.Errorf("cannot open pipeline: %v", err)
+		}
+		startCancel()
+
+		r.writingFiles.Add(filepath.Base(info.OutputPath()))
+		r.pipes.Store(roomId, pipe)
+
+		err = r.rev(roomId, ch, info, ctx, pipe)
+		if err != nil {
+			var headerChanged *flv.FlvHeaderChangedError
+			if errors.As(err, &headerChanged) {
+				l.Info("rotating file due to video header change detected in stream")
+				videoHdr = headerChanged.VideoHeaderTag
+				audioHdr = headerChanged.AudioHeaderTag
+				// Before starting a new segment, reset the fixer's timestamp tracking
+				// so the new segment's timestamps start from 0 instead of continuing
+				// from the previous segment's time range.
+				sharedFixer.ResetTimestampStore()
+				segment++
+				continue
+			} else if err == processors.ErrNotFlvFile {
+				l.Warn("stream format invalid, aborting recording")
+				// Wait before aborting to prevent rapid reconnection loops (e.g. when stream URL
+				// briefly returns garbage before stabilizing). This mirrors the original 5-second
+				// buffer introduced in d8425df.
 				timer := time.NewTimer(5 * time.Second)
 				select {
 				case <-timer.C:
-					return
-				case <-r.ctx.Done():
+				case <-ctx.Done():
 					timer.Stop()
-					return
 				}
+				break
+			} else {
+				l.Errorf("error writing data to file: %v", err)
 			}
-			return
+		}
+		break
+	}
+	return nil
+}
+
+func (r *Service) rev(roomId int, ch <-chan []byte, info *Info, ctx context.Context, pipe *pipeline.Pipe[[]byte]) error {
+	defer func() {
+		pipe.Close()
+		outputPath := info.OutputPath()
+		go r.finalize(roomId, outputPath)
+	}()
+	for data := range ch {
+		info.bytesRead.Add(uint64(len(data)))
+		result, err := pipe.Process(ctx, data)
+		r.st.Flush(data)
+		if err != nil {
+			// "abandoned" bytes = pipeline output size at the moment of error, not input size.
+			// Observed values:
+			//   0B    — split at chunk boundary, no carried bytes (most common, harmless)
+			//   ~4.6KB — carried bytes from a rotation split; replayed into next segment, not lost
+			// At 6 Mbps, 5000B ≈ 6 ms ≈ <0.25 frame at 60 fps — imperceptible in recordings.
+			logger.WithField("room", roomId).Warnf("abandoned flv stream chunk: %dB", len(result))
+			return err
 		}
 	}
+	return nil
 }
 
 func (r *Service) checkRecordingDurationPeriodically(roomId int, ctx context.Context) {
@@ -340,7 +379,7 @@ func (r *Service) recover(roomId int) {
 
 			l.Infof("will retry stream recovery in 15 seconds...")
 			timer := time.NewTimer(15 * time.Second)
-			
+
 			select {
 			case <-timer.C:
 				attempt++
@@ -355,22 +394,22 @@ func (r *Service) recover(roomId int) {
 	}
 }
 
-func (r *Service) finalize(roomId int, info *Recorder) {
-	if info == nil {
-		logger.Warnf("skipping finalize for room %d: no recording info", roomId)
+func (r *Service) finalize(roomId int, outputPath string) {
+	if outputPath == "" {
+		logger.Warnf("skipping finalize for room %d: output path is empty", roomId)
 		return
 	}
 
-	defer r.writtingFiles.Remove(filepath.Base(info.outputPath))
+	defer r.writingFiles.Remove(filepath.Base(outputPath))
 
-	fileInfo, err := os.Stat(info.outputPath)
+	fileInfo, err := os.Stat(outputPath)
 	if err != nil {
 		logger.Errorf("failed to stat recorded file for room %d: %v", roomId, err)
 		return
 	} else if fileInfo.Size() < 1024 { // less than 1KB
 		logger.Warnf("recorded file for room %d is too small (%d bytes), skipping finallization and removing file", roomId, fileInfo.Size())
-		if err := os.Remove(info.outputPath); err != nil {
-			logger.Errorf("failed to remove empty file %s: %v", info.outputPath, err)
+		if err := os.Remove(outputPath); err != nil {
+			logger.Errorf("failed to remove empty file %s: %v", outputPath, err)
 		}
 		return
 	}
@@ -381,7 +420,7 @@ func (r *Service) finalize(roomId int, info *Recorder) {
 	}
 
 	// process finalization via convert service
-	if queue, err := r.cv.Enqueue(info.outputPath, "mp4", r.cfg.DeleteFlvAfterConvert); err != nil {
+	if queue, err := r.cv.Enqueue(outputPath, "mp4", r.cfg.DeleteFlvAfterConvert); err != nil {
 		logger.Errorf("failed to enqueue conversion for room %d: %v", roomId, err)
 		logger.Warnf("you may need to convert mp4 manually for room: %d", roomId)
 	} else {
@@ -431,13 +470,17 @@ func (r *Service) backgroundMaintenance(ctx context.Context) {
 }
 
 // the time should be the time you start the record, not live start
-func (r *Service) prepareFilePath(info *bilibili.LiveRoomInfoDetail, start time.Time) (string, error) {
-	dirPath := fmt.Sprintf("%s/%s-%d", r.cfg.OutputDir, info.Uname, info.RoomID)
+func (r *Service) rotateFilePath(info *Info, segment int) (string, error) {
+	dirPath := fmt.Sprintf("%s/%s-%d", r.cfg.OutputDir, info.room.Uname, info.room.RoomID)
 	if err := os.MkdirAll(dirPath, 0755); err != nil {
 		return "", err
 	}
-	safeTitle := utils.TruncateString(utils.SanitizeFilename(info.Title), 20)
-	return fmt.Sprintf("%s/%s-%s.flv", dirPath, safeTitle, start.Format("20060102_150405")), nil
+	safeTitle := utils.TruncateString(utils.SanitizeFilename(info.room.Title), 20)
+	if segment == 0 {
+		return fmt.Sprintf("%s/%s-%s.flv", dirPath, safeTitle, info.startTime.Format("20060102_150405")), nil
+	} else {
+		return fmt.Sprintf("%s/%s-%s-%d.flv", dirPath, safeTitle, info.startTime.Format("20060102_150405"), segment), nil
+	}
 }
 
 func initOutputDir(cfg *config.Config) {

--- a/internal/services/recorder/recorder_test.go
+++ b/internal/services/recorder/recorder_test.go
@@ -1,8 +1,10 @@
 package recorder_test
 
 import (
+	"fmt"
 	"os"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,7 +20,7 @@ import (
 
 func TestFlvRecord(t *testing.T) {
 
-	const room = 1842862714
+	const room = 1777483153
 
 	var recorderService *recorder.Service
 
@@ -63,6 +65,75 @@ func TestFlvRecord(t *testing.T) {
 	t.Logf("memory after stop: %.2f MB", float64(m3.Alloc/1024/1024))
 	t.Logf("growth during recording: %.2f MB", float64((m2.Alloc-m1.Alloc)/1024/1024))
 	t.Logf("growth after stop: %.2f MB", float64((m3.Alloc-m2.Alloc)/1024/1024))
+}
+
+func TestChannelRangeReturnedWhileStreaming(t *testing.T) {
+	ch := make(chan int, 10)
+	// give some random elements keep sending to channel
+	send := func() {
+		for i := 0; i < 10; i++ {
+			ch <- i
+			time.Sleep(1 * time.Second)
+		}
+		close(ch)
+	}
+	go send()
+	// range over channel and print elements
+	for v := range ch {
+		t.Logf("received: %d", v)
+		if v == 5 {
+			t.Log("stop early")
+			break
+		}
+	}
+	<-time.After(5 * time.Second)
+	for v := range ch {
+		t.Logf("received after first range stopped: %d", v)
+	}
+}
+
+func TestInfoOutputPath_DefaultEmpty(t *testing.T) {
+	info := &recorder.Info{}
+	if got := info.OutputPath(); got != "" {
+		t.Fatalf("expected empty output path, got %q", got)
+	}
+}
+
+func TestInfoOutputPath_AtomicConcurrentReadWrite(t *testing.T) {
+	info := &recorder.Info{}
+	info.SetOutputPath("")
+
+	const writers = 8
+	const readers = 8
+	const loops = 2000
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for n := 0; n < loops; n++ {
+				info.SetOutputPath(fmt.Sprintf("seg-%d-%d.flv", id, n))
+			}
+		}(i)
+	}
+
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for n := 0; n < loops; n++ {
+				_ = info.OutputPath()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if got := info.OutputPath(); got == "" {
+		t.Fatal("expected non-empty output path after concurrent writes")
+	}
 }
 
 func init() {

--- a/internal/services/recorder/stats.go
+++ b/internal/services/recorder/stats.go
@@ -29,7 +29,7 @@ func (r *Service) GetStatus(roomId int) RecordStatus {
 
 func (r *Service) ListRecording() []int {
 	rooms := make([]int, 0)
-	r.recording.Range(func(key int, value *Recorder) bool {
+	r.recording.Range(func(key int, value *Info) bool {
 		rooms = append(rooms, key)
 		return true
 	})
@@ -47,12 +47,12 @@ func (r *Service) GetStats(roomId int) (*Stats, bool) {
 		Status:         status,
 		StartTime:      info.startTime.Unix(),
 		ElapsedSeconds: int64(time.Since(info.startTime).Seconds()),
-		OutputPath:     info.outputPath,
+		OutputPath:     info.OutputPath(),
 	}, true
 }
 
 func (r *Service) IsRecording(path string) bool {
-	return r.writtingFiles.Contains(filepath.Base(path))
+	return r.writingFiles.Contains(filepath.Base(path))
 }
 
 // IsRecordingUnder checks if any recordings are happening under the given relative path.

--- a/pkg/flv/accumulate_fixer.go
+++ b/pkg/flv/accumulate_fixer.go
@@ -85,7 +85,7 @@ func (af *AccumulateFixer) Close() {
 
 	if af.buffer != nil {
 		af.buffer.Reset()
-		byteBufferPool.Put(af.buffer)
+		accumulateBufferPool.Put(af.buffer)
 		af.buffer = nil
 	}
 
@@ -108,7 +108,7 @@ func (af *AccumulateFixer) flushInternal() ([]byte, error) {
 	}
 
 	// 🔥 優化: 從 pool 取得 output buffer
-	output := byteBufferPool.Get()
+	output := accumulateBufferPool.Get()
 	output.Reset()
 
 	// Write header once globally (not per flush)
@@ -145,14 +145,14 @@ func (af *AccumulateFixer) flushInternal() ([]byte, error) {
 
 		if af.buffer.Len() < TagHeaderSize {
 			// Restore
-			tempBuf := byteBufferPool.Get()
+			tempBuf := accumulateBufferPool.Get()
 			tempBuf.Reset()
 			tempBuf.Write(prevTagSizeBytes)
 			tempBuf.Write(af.buffer.Bytes())
 			af.buffer.Reset()
 			af.buffer.Write(tempBuf.Bytes())
 			tempBuf.Reset()
-			byteBufferPool.Put(tempBuf)
+			accumulateBufferPool.Put(tempBuf)
 			smallBytesPool.PutBytes(prevTagSizeBytes)
 			break
 		}
@@ -164,7 +164,7 @@ func (af *AccumulateFixer) flushInternal() ([]byte, error) {
 
 		if af.buffer.Len() < int(dataSize) {
 			// Incomplete tag, restore buffer
-			tempBuf := byteBufferPool.Get()
+			tempBuf := accumulateBufferPool.Get()
 			tempBuf.Reset()
 			tempBuf.Write(prevTagSizeBytes)
 			tempBuf.Write(headerBytes)
@@ -172,7 +172,7 @@ func (af *AccumulateFixer) flushInternal() ([]byte, error) {
 			af.buffer.Reset()
 			af.buffer.Write(tempBuf.Bytes())
 			tempBuf.Reset()
-			byteBufferPool.Put(tempBuf)
+			accumulateBufferPool.Put(tempBuf)
 			headerBytesPool.PutBytes(headerBytes)
 			smallBytesPool.PutBytes(prevTagSizeBytes)
 			break
@@ -248,7 +248,7 @@ func (af *AccumulateFixer) flushInternal() ([]byte, error) {
 	copy(result, output.Bytes())
 
 	output.Reset()
-	byteBufferPool.Put(output)
+	accumulateBufferPool.Put(output)
 
 	return result, nil
 }

--- a/pkg/flv/fixer.go
+++ b/pkg/flv/fixer.go
@@ -46,8 +46,12 @@ var (
 	ErrInvalidTag      = errors.New("invalid FLV tag")
 	ErrBufferCorrupted = errors.New("buffer corruption detected")
 
-	// 🔥 優化: sync.Pool 用於復用 buffer 和對象
-	byteBufferPool = pool.NewBufferPool(DefaultBufferSize, MaxBufferSize)
+	// Dedicated pool for AccumulateFixer batch processing.
+	accumulateBufferPool = pool.NewBufferPool(DefaultBufferSize, MaxBufferSize)
+	// Dedicated pool for RealtimeFixer to isolate frequent live-room start/stop churn.
+	realtimeBufferPool = pool.NewBufferPool(DefaultBufferSize, MaxBufferSize)
+	// Dedicated pool for HeaderChangeDetector to isolate parser scratch usage.
+	headerDetectorBufferPool = pool.NewBufferPool(DefaultBufferSize, MaxBufferSize)
 
 	tagPool = sync.Pool{
 		New: func() any {

--- a/pkg/flv/flv_integration_test.go
+++ b/pkg/flv/flv_integration_test.go
@@ -1,0 +1,226 @@
+package flv_test
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/eric2788/bilirec/pkg/flv"
+)
+
+func TestRealtimeFixer(t *testing.T) {
+	// ============================================
+	// Example 1: Realtime Fixer
+	// ============================================
+	realtimeFixer := flv.NewRealtimeFixer()
+	defer realtimeFixer.Close()
+
+	inputChannel := make(chan []byte, 100)
+	done := make(chan bool)
+
+	if _, err := os.Stat("original.flv"); err != nil {
+		if os.IsNotExist(err) {
+			t.Skipf("skipping realtime fixer integration test: fixture %q not found", "original.flv")
+		}
+		t.Fatalf("Failed to stat input fixture: %v", err)
+	}
+
+	outputFile, err := os.Create("output_realtime.flv")
+	if err != nil {
+		t.Fatalf("Failed to create output file: %v", err)
+	}
+	defer outputFile.Close()
+
+	var totalRead int64
+	var totalWritten int64
+	var chunkCount int
+
+	go func() {
+		defer close(done)
+
+		for chunk := range inputChannel {
+			chunkCount++
+			totalRead += int64(len(chunk))
+
+			fixed, err := realtimeFixer.Fix(chunk)
+			if err != nil {
+				t.Errorf("❌ Fix error on chunk #%d: %v", chunkCount, err)
+				continue
+			}
+
+			if len(fixed) > 0 {
+				written, err := outputFile.Write(fixed)
+				if err != nil {
+					t.Errorf("❌ Write error:  %v", err)
+					continue
+				}
+				totalWritten += int64(written)
+
+				// 每 100 個 chunk 輸出進度
+				if chunkCount%100 == 0 {
+					t.Logf("📊 Progress: %d chunks, %d KB read, %d KB written",
+						chunkCount, totalRead/1024, totalWritten/1024)
+				}
+			}
+		}
+
+		t.Logf("✅ Processing complete: %d chunks processed", chunkCount)
+	}()
+
+	// Feed data from source
+	t.Log("📥 Starting to read original. flv...")
+	sendFile(t, "original.flv", inputChannel)
+
+	// Wait for processing to complete
+	<-done
+
+	// Validate output
+	stat, err := outputFile.Stat()
+	if err != nil {
+		t.Fatalf("Failed to stat output file: %v", err)
+	}
+
+	if stat.Size() == 0 {
+		t.Error("❌ Output file is empty!")
+	} else {
+		t.Logf("✅ Realtime fix complete:  %d bytes read, %d bytes written",
+			totalRead, totalWritten)
+		t.Logf("📁 Output file size: %d bytes (%.2f MB)",
+			stat.Size(), float64(stat.Size())/(1024*1024))
+
+		// 計算壓縮率/膨脹率
+		ratio := float64(totalWritten) / float64(totalRead) * 100
+		t.Logf("📈 Size ratio: %.2f%% (output/input)", ratio)
+	}
+
+	dups, size, capacity := realtimeFixer.GetDedupStats()
+	t.Logf("🗂️ Dedup Stats: %d duplicates detected, cache size: %d/%d", dups, size, capacity)
+}
+
+func TestAccumulateFix(t *testing.T) {
+	// ============================================
+	// Example 2: Accumulate Fixer (每 10MB 輸出)
+	// ============================================
+	accFixer := flv.NewAccumulateFixer(10) // 10 MB chunks
+	defer accFixer.Close()
+
+	if _, err := os.Stat("original.flv"); err != nil {
+		if os.IsNotExist(err) {
+			t.Skipf("skipping accumulate fixer integration test: fixture %q not found", "original.flv")
+		}
+		t.Fatalf("Failed to stat input fixture: %v", err)
+	}
+
+	outputFile2, err := os.Create("output_accumulated.flv")
+	if err != nil {
+		t.Fatalf("Failed to create output file: %v", err)
+	}
+	defer outputFile2.Close()
+
+	inputChannel2 := make(chan []byte, 100)
+	done := make(chan bool)
+
+	var totalWritten int64
+	var flushCount int
+
+	go func() {
+		defer close(done)
+
+		for chunk := range inputChannel2 {
+			shouldFlush, err := accFixer.Accumulate(chunk)
+			if err != nil {
+				t.Errorf("Accumulate error: %v", err)
+				continue
+			}
+
+			if shouldFlush {
+				buffered, processed := accFixer.GetStats()
+				t.Logf("📊 Stats before flush: buffered=%d, processed=%d", buffered, processed)
+
+				fixed, err := accFixer.Flush()
+				if err != nil {
+					t.Errorf("Flush error: %v", err)
+					continue
+				}
+
+				if len(fixed) > 0 {
+					written, err := outputFile2.Write(fixed)
+					if err != nil {
+						t.Errorf("Write error: %v", err)
+						continue
+					}
+					totalWritten += int64(written)
+					flushCount++
+					t.Logf("✅ Flush #%d: wrote %d bytes", flushCount, written)
+				}
+			}
+		}
+
+		// 🔥 重要: 使用 FlushRemaining() 而不是 Flush()
+		t.Log("📦 Flushing remaining data...")
+		final, err := accFixer.FlushRemaining()
+		if err != nil {
+			t.Errorf("⚠️ Final flush error: %v", err)
+		} else if len(final) > 0 {
+			written, err := outputFile2.Write(final)
+			if err != nil {
+				t.Errorf("Final write error: %v", err)
+			} else {
+				totalWritten += int64(written)
+				flushCount++
+				t.Logf("✅ Final flush:  wrote %d bytes", written)
+			}
+		}
+
+		t.Logf("✅ Total written: %d bytes in %d flushes", totalWritten, flushCount)
+	}()
+
+	// 發送文件數據
+	sendFile(t, "original.flv", inputChannel2)
+
+	// 等待處理完成
+	<-done
+
+	// 驗證輸出
+	stat, err := outputFile2.Stat()
+	if err != nil {
+		t.Fatalf("Failed to stat output file: %v", err)
+	}
+
+	if stat.Size() == 0 {
+		t.Error("❌ Output file is empty!")
+	} else {
+		t.Logf("✅ Output file size: %d bytes", stat.Size())
+	}
+
+	dups, size, capacity := accFixer.GetDedupStats()
+	t.Logf("🗂️ Dedup Stats: %d duplicates detected, cache size: %d/%d", dups, size, capacity)
+}
+
+func sendFile(t *testing.T, file string, ch chan<- []byte) {
+	f, err := os.Open(file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Skipf("skipping test for missing fixture: %q", file)
+			return
+		}
+		t.Fatalf("Failed to open %q: %v", file, err)
+		return
+	}
+	defer f.Close()
+
+	defer close(ch)
+	for {
+		buf := make([]byte, 4096)
+		n, err := f.Read(buf)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n > 0 {
+			ch <- buf[:n]
+		}
+	}
+}

--- a/pkg/flv/flv_test.go
+++ b/pkg/flv/flv_test.go
@@ -1,183 +1,172 @@
 package flv_test
 
 import (
-	"io"
-	"os"
+	"encoding/binary"
+	"errors"
 	"testing"
 
 	"github.com/eric2788/bilirec/pkg/flv"
 )
 
-func TestRealtimeFixer(t *testing.T) {
-	// ============================================
-	// Example 1: Realtime Fixer
-	// ============================================
-	realtimeFixer := flv.NewRealtimeFixer()
-
-	inputChannel := make(chan []byte, 100)
-	done := make(chan bool)
-
-	outputFile, err := os.Create("output_realtime.flv")
-	if err != nil {
-		t.Fatalf("Failed to create output file: %v", err)
+func TestFlvHeaderWriter_Prepend_NoOptionalHeaders(t *testing.T) {
+	w := &flv.FlvHeaderWriter{}
+	out := w.Prepend([]byte{0x09, 0xaa})
+	want := len(flv.NewFileHeaderBytes()) + 2
+	if len(out) != want {
+		t.Fatalf("expected %d bytes, got %d", want, len(out))
 	}
-	defer outputFile.Close()
-
-	var totalRead int64
-	var totalWritten int64
-	var chunkCount int
-
-	go func() {
-		defer close(done)
-
-		for chunk := range inputChannel {
-			chunkCount++
-			totalRead += int64(len(chunk))
-
-			fixed, err := realtimeFixer.Fix(chunk)
-			if err != nil {
-				t.Errorf("❌ Fix error on chunk #%d: %v", chunkCount, err)
-				continue
-			}
-
-			if len(fixed) > 0 {
-				written, err := outputFile.Write(fixed)
-				if err != nil {
-					t.Errorf("❌ Write error:  %v", err)
-					continue
-				}
-				totalWritten += int64(written)
-
-				// 每 100 個 chunk 輸出進度
-				if chunkCount%100 == 0 {
-					t.Logf("📊 Progress: %d chunks, %d KB read, %d KB written",
-						chunkCount, totalRead/1024, totalWritten/1024)
-				}
-			}
-		}
-
-		t.Logf("✅ Processing complete: %d chunks processed", chunkCount)
-	}()
-
-	// Feed data from source
-	t.Log("📥 Starting to read original. flv...")
-	sendFile(t, "original.flv", inputChannel)
-
-	// Wait for processing to complete
-	<-done
-
-	// Validate output
-	stat, err := outputFile.Stat()
-	if err != nil {
-		t.Fatalf("Failed to stat output file: %v", err)
+	if string(out[len(flv.NewFileHeaderBytes()):]) != string([]byte{0x09, 0xaa}) {
+		t.Fatal("payload was not appended correctly")
 	}
-
-	if stat.Size() == 0 {
-		t.Error("❌ Output file is empty!")
-	} else {
-		t.Logf("✅ Realtime fix complete:  %d bytes read, %d bytes written",
-			totalRead, totalWritten)
-		t.Logf("📁 Output file size: %d bytes (%.2f MB)",
-			stat.Size(), float64(stat.Size())/(1024*1024))
-
-		// 計算壓縮率/膨脹率
-		ratio := float64(totalWritten) / float64(totalRead) * 100
-		t.Logf("📈 Size ratio: %.2f%% (output/input)", ratio)
-	}
-
-	dups, size, capacity := realtimeFixer.GetDedupStats()
-	t.Logf("🗂️ Dedup Stats: %d duplicates detected, cache size: %d/%d", dups, size, capacity)
 }
 
-func TestAccumulateFix(t *testing.T) {
-	// ============================================
-	// Example 2: Accumulate Fixer (每 10MB 輸出)
-	// ============================================
-	accFixer := flv.NewAccumulateFixer(10) // 10 MB chunks
-	outputFile2, err := os.Create("output_accumulated.flv")
+func TestFlvHeaderWriter_Prepend_WithHeaders(t *testing.T) {
+	vTag := flv.NewTagBytes(flv.TagTypeVideo, []byte{0x17, 0x00, 0x00})
+	aTag := flv.NewTagBytes(flv.TagTypeAudio, []byte{0xaf, 0x00, 0x12})
+	w := &flv.FlvHeaderWriter{
+		VideoHeaderTag: vTag,
+		AudioHeaderTag: aTag,
+	}
+	payload := []byte{0x09, 0x01}
+	out := w.Prepend(payload)
+	want := len(flv.NewFileHeaderBytes()) + len(vTag) + len(aTag) + len(payload)
+	if len(out) != want {
+		t.Fatalf("expected %d bytes, got %d", want, len(out))
+	}
+}
+
+func TestFlvHeaderWriter_Prepend_NormalizesInjectedHeaderTimestamps(t *testing.T) {
+	vTag := flv.NewTagBytes(flv.TagTypeVideo, []byte{0x17, 0x00, 0x00})
+	aTag := flv.NewTagBytes(flv.TagTypeAudio, []byte{0xaf, 0x00, 0x12})
+
+	// Simulate headers captured from an ongoing stream with non-zero timestamps.
+	vTag[4], vTag[5], vTag[6], vTag[7] = 0x01, 0x02, 0x03, 0x04
+	aTag[4], aTag[5], aTag[6], aTag[7] = 0x10, 0x20, 0x30, 0x40
+
+	w := &flv.FlvHeaderWriter{
+		VideoHeaderTag: vTag,
+		AudioHeaderTag: aTag,
+	}
+	out := w.Prepend([]byte{0x09})
+
+	preamble := len(flv.NewFileHeaderBytes())
+	videoStart := preamble
+	audioStart := preamble + len(vTag)
+
+	if out[videoStart+4] != 0 || out[videoStart+5] != 0 || out[videoStart+6] != 0 || out[videoStart+7] != 0 {
+		t.Fatal("expected video header timestamp to be normalized to zero")
+	}
+	if out[audioStart+4] != 0 || out[audioStart+5] != 0 || out[audioStart+6] != 0 || out[audioStart+7] != 0 {
+		t.Fatal("expected audio header timestamp to be normalized to zero")
+	}
+
+	// Ensure source tags are not mutated by Prepend.
+	if vTag[4] == 0 && vTag[5] == 0 && vTag[6] == 0 && vTag[7] == 0 {
+		t.Fatal("source video tag should not be mutated")
+	}
+	if aTag[4] == 0 && aTag[5] == 0 && aTag[6] == 0 && aTag[7] == 0 {
+		t.Fatal("source audio tag should not be mutated")
+	}
+}
+
+func TestFlvHeaderChangedError_Is(t *testing.T) {
+	e := &flv.FlvHeaderChangedError{
+		VideoHeaderTag: []byte{0x01},
+	}
+	if !errors.Is(e, flv.ErrVideoHeaderChanged) {
+		t.Fatal("FlvHeaderChangedError should match ErrVideoHeaderChanged via errors.Is")
+	}
+}
+
+func TestRealtimeFixer_SkipsSourceHeader(t *testing.T) {
+	fixer := flv.NewRealtimeFixer()
+	defer fixer.Close()
+
+	out, err := fixer.Fix(flv.FlvHeader)
 	if err != nil {
-		t.Fatalf("Failed to create output file: %v", err)
+		t.Fatalf("unexpected error on FLV header input: %v", err)
 	}
-	defer outputFile2.Close()
+	if len(out) != 0 {
+		t.Fatalf("expected no output when only FLV file header is consumed, got %d bytes", len(out))
+	}
+}
 
-	inputChannel2 := make(chan []byte, 100)
-	done := make(chan bool)
+func TestRealtimeFixer_MidStream_NoHeaderInInput(t *testing.T) {
+	// Simulate segment N: reset marks the next input as a rotation segment
+	// that starts at a tag boundary without an FLV file header.
+	fixer := flv.NewRealtimeFixer()
+	defer fixer.Close()
+	fixer.ResetTimestampStore()
 
-	var totalWritten int64
-	var flushCount int
+	// Rotation-segment input starts with PreviousTagSize of the prior tag,
+	// followed by a full tag (header + payload + trailing PreviousTagSize).
+	tag := flv.NewTagBytes(flv.TagTypeAudio, []byte{0xaf, 0x01, 0x11})
+	in := make([]byte, 0, flv.PrevTagSizeBytes+len(tag))
+	in = append(in, 0, 0, 0, 0)
+	in = append(in, tag...)
 
-	go func() {
-		defer close(done)
-
-		for chunk := range inputChannel2 {
-			shouldFlush, err := accFixer.Accumulate(chunk)
-			if err != nil {
-				t.Errorf("Accumulate error: %v", err)
-				continue
-			}
-
-			if shouldFlush {
-				buffered, processed := accFixer.GetStats()
-				t.Logf("📊 Stats before flush: buffered=%d, processed=%d", buffered, processed)
-
-				fixed, err := accFixer.Flush()
-				if err != nil {
-					t.Errorf("Flush error: %v", err)
-					continue
-				}
-
-				if len(fixed) > 0 {
-					written, err := outputFile2.Write(fixed)
-					if err != nil {
-						t.Errorf("Write error: %v", err)
-						continue
-					}
-					totalWritten += int64(written)
-					flushCount++
-					t.Logf("✅ Flush #%d: wrote %d bytes", flushCount, written)
-				}
-			}
-		}
-
-		// 🔥 重要: 使用 FlushRemaining() 而不是 Flush()
-		t.Log("📦 Flushing remaining data...")
-		final, err := accFixer.FlushRemaining()
-		if err != nil {
-			t.Errorf("⚠️ Final flush error: %v", err)
-		} else if len(final) > 0 {
-			written, err := outputFile2.Write(final)
-			if err != nil {
-				t.Errorf("Final write error: %v", err)
-			} else {
-				totalWritten += int64(written)
-				flushCount++
-				t.Logf("✅ Final flush:  wrote %d bytes", written)
-			}
-		}
-
-		t.Logf("✅ Total written: %d bytes in %d flushes", totalWritten, flushCount)
-	}()
-
-	// 發送文件數據
-	sendFile(t, "original.flv", inputChannel2)
-
-	// 等待處理完成
-	<-done
-
-	// 驗證輸出
-	stat, err := outputFile2.Stat()
+	out, err := fixer.Fix(in)
 	if err != nil {
-		t.Fatalf("Failed to stat output file: %v", err)
+		t.Fatalf("rotation-segment mid-stream data should not produce an error, got: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected processed output for valid mid-stream rotation-segment tag")
+	}
+}
+
+func TestRealtimeFixer_ClampsNegativeTimestampAfterReset(t *testing.T) {
+	fixer := flv.NewRealtimeFixer()
+	defer fixer.Close()
+	fixer.ResetTimestampStore()
+
+	// Build two tags where the second tag timestamp goes backward slightly.
+	tag1 := flv.NewTagBytes(flv.TagTypeAudio, []byte{0xaf, 0x01, 0x11})
+	tag1[4], tag1[5], tag1[6], tag1[7] = 0x00, 0x01, 0x2c, 0x00 // 300ms
+
+	tag2 := flv.NewTagBytes(flv.TagTypeAudio, []byte{0xaf, 0x01, 0x22})
+	tag2[4], tag2[5], tag2[6], tag2[7] = 0x00, 0x01, 0x2a, 0x00 // 298ms
+
+	in := make([]byte, 0, flv.PrevTagSizeBytes+len(tag1)+len(tag2))
+	in = append(in, 0, 0, 0, 0)
+	in = append(in, tag1...)
+	in = append(in, tag2...)
+	out, err := fixer.Fix(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if stat.Size() == 0 {
-		t.Error("❌ Output file is empty!")
-	} else {
-		t.Logf("✅ Output file size: %d bytes", stat.Size())
+	if len(out) < (flv.TagHeaderSize+3+flv.PrevTagSizeBytes)*2 {
+		t.Fatalf("unexpected output size: %d", len(out))
 	}
 
-	dups, size, capacity := accFixer.GetDedupStats()
-	t.Logf("🗂️ Dedup Stats: %d duplicates detected, cache size: %d/%d", dups, size, capacity)
+	firstTagLen := flv.TagHeaderSize + 3 + flv.PrevTagSizeBytes
+	secondHeader := out[firstTagLen : firstTagLen+flv.TagHeaderSize]
+	secondTs := uint32(secondHeader[7])<<24 | uint32(secondHeader[4])<<16 | uint32(secondHeader[5])<<8 | uint32(secondHeader[6])
+	if secondTs > 1000 {
+		t.Fatalf("expected clamped non-negative timestamp for second tag, got %dms", secondTs)
+	}
+
+	// Guard against wrapped value near uint32 max.
+	if secondTs > 0xF0000000 {
+		t.Fatalf("timestamp wrapped unexpectedly: %d", secondTs)
+	}
+
+	// Ensure PrevTagSize is still valid for the second tag.
+	secondPrev := binary.BigEndian.Uint32(out[firstTagLen+flv.TagHeaderSize+3 : firstTagLen+flv.TagHeaderSize+3+flv.PrevTagSizeBytes])
+	if secondPrev != uint32(flv.TagHeaderSize+3) {
+		t.Fatalf("unexpected prev tag size: %d", secondPrev)
+	}
+}
+
+func TestNewTagBytes_BuildsPrevTagSize(t *testing.T) {
+	payload := []byte{0x17, 0x00, 0x00}
+	tag := flv.NewTagBytes(flv.TagTypeVideo, payload)
+	if len(tag) != flv.TagHeaderSize+len(payload)+flv.PrevTagSizeBytes {
+		t.Fatalf("unexpected tag length: %d", len(tag))
+	}
+	if got := uint32(tag[len(tag)-4])<<24 | uint32(tag[len(tag)-3])<<16 | uint32(tag[len(tag)-2])<<8 | uint32(tag[len(tag)-1]); got != uint32(flv.TagHeaderSize+len(payload)) {
+		t.Fatalf("unexpected prev tag size: %d", got)
+	}
 }
 
 func TestTagPool_ClearsDataOnPut(t *testing.T) {
@@ -191,30 +180,119 @@ func TestTagPool_ClearsDataOnPut(t *testing.T) {
 	}
 }
 
-func sendFile(t *testing.T, file string, ch chan<- []byte) {
-	f, err := os.Open(file)
-	if err != nil {
-		if os.IsNotExist(err) {
-			t.Skipf("skip for: %v", err)
-			return
-		}
-		t.Fatalf("Failed to open original.flv: %v", err)
-		return
-	}
-	defer f.Close()
+func TestHeaderChangeDetector_DetectsSequenceHeaderChange(t *testing.T) {
+	d := flv.NewHeaderChangeDetector()
 
-	defer close(ch)
-	for {
-		buf := make([]byte, 4096)
-		n, err := f.Read(buf)
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatal(err)
-		}
-		if n > 0 {
-			ch <- buf[:n]
-		}
+	h1 := []byte{0x17, 0x00, 0x00, 0x00, 0x00, 0x01, 0x42, 0x00, 0x1e}
+	h2 := []byte{0x17, 0x00, 0x00, 0x00, 0x00, 0x01, 0x42, 0x00, 0x2a}
+
+	chunk1 := buildFLVVideoTag(h1)
+	chunk2 := buildFLVVideoTag(h2)
+
+	if err := d.DetectChange(chunk1); err != nil {
+		t.Fatalf("first sequence header should not trigger split, got err: %v", err)
 	}
+
+	err := d.DetectChange(chunk2)
+	if !errors.Is(err, flv.ErrVideoHeaderChanged) {
+		t.Fatalf("expected ErrVideoHeaderChanged, got: %v", err)
+	}
+}
+
+func TestHeaderChangeDetector_DetectsSequenceHeaderChangeAcrossChunks(t *testing.T) {
+	d := flv.NewHeaderChangeDetector()
+
+	h1 := []byte{0x17, 0x00, 0x00, 0x00, 0x00, 0x01, 0x42, 0x00, 0x1e}
+	h2 := []byte{0x17, 0x00, 0x00, 0x00, 0x00, 0x01, 0x64, 0x00, 0x29}
+
+	tag1 := buildFLVVideoTag(h1)
+	tag2 := buildFLVVideoTag(h2)
+
+	if err := d.DetectChange(tag1); err != nil {
+		t.Fatalf("first sequence header should not trigger split, got err: %v", err)
+	}
+
+	// Split second tag across chunks to emulate network boundary split.
+	splitAt := len(tag2) / 2
+	if err := d.DetectChange(tag2[:splitAt]); err != nil {
+		t.Fatalf("partial chunk should not trigger split yet, got err: %v", err)
+	}
+
+	err := d.DetectChange(tag2[splitAt:])
+	if !errors.Is(err, flv.ErrVideoHeaderChanged) {
+		t.Fatalf("expected ErrVideoHeaderChanged across chunks, got: %v", err)
+	}
+}
+
+func TestHeaderChangeDetector_KeepsPendingWhenPrevTagSizeSplitAcrossChunks(t *testing.T) {
+	d := flv.NewHeaderChangeDetector()
+
+	h1 := []byte{0x17, 0x00, 0x00, 0x00, 0x00, 0x01, 0x42, 0x00, 0x1e}
+	h2 := []byte{0x17, 0x00, 0x00, 0x00, 0x00, 0x01, 0x64, 0x00, 0x29}
+
+	tag1 := buildFLVVideoTag(h1)
+	tag2 := buildFLVVideoTag(h2)
+
+	if err := d.DetectChange(tag1[:len(tag1)-flv.PrevTagSizeBytes]); err != nil {
+		t.Fatalf("partial first tag ending before PrevTagSize should not fail, got err: %v", err)
+	}
+
+	err := d.DetectChange(append(tag1[len(tag1)-flv.PrevTagSizeBytes:], tag2...))
+	if !errors.Is(err, flv.ErrVideoHeaderChanged) {
+		t.Fatalf("expected ErrVideoHeaderChanged after replaying split PrevTagSize, got: %v", err)
+	}
+}
+
+func TestHeaderChangeDetector_IgnoresNonSequenceVideo(t *testing.T) {
+	d := flv.NewHeaderChangeDetector()
+
+	// AVCPacketType = 1, not sequence header
+	videoNalu := []byte{0x17, 0x01, 0x00, 0x00, 0x00, 0xaa, 0xbb, 0xcc}
+	chunk := buildFLVVideoTag(videoNalu)
+
+	if err := d.DetectChange(chunk); err != nil {
+		t.Fatalf("non-sequence video should not trigger split, got err: %v", err)
+	}
+}
+
+func TestHeaderChangeDetector_LastVideoHeaderReturnsCopy(t *testing.T) {
+	d := flv.NewHeaderChangeDetector()
+
+	h := []byte{0x17, 0x00, 0x00, 0x00, 0x00, 0x01, 0x42, 0x00, 0x1e}
+	if err := d.DetectChange(buildFLVVideoTag(h)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	a := d.LastVideoHeader()
+	if len(a) == 0 {
+		t.Fatal("expected non-empty last video header")
+	}
+	a[0] ^= 0xff
+
+	b := d.LastVideoHeader()
+	if a[0] == b[0] {
+		t.Fatal("LastVideoHeader should return a copy, got shared backing array")
+	}
+}
+
+func buildFLVVideoTag(payload []byte) []byte {
+	dataSize := len(payload)
+	tagHeader := make([]byte, 11)
+	tagHeader[0] = flv.TagTypeVideo
+	tagHeader[1] = byte(dataSize >> 16)
+	tagHeader[2] = byte(dataSize >> 8)
+	tagHeader[3] = byte(dataSize)
+
+	out := make([]byte, 0, 11+dataSize+4)
+	out = append(out, tagHeader...)
+	out = append(out, payload...)
+
+	prevTagSize := uint32(11 + dataSize)
+	out = append(out,
+		byte(prevTagSize>>24),
+		byte(prevTagSize>>16),
+		byte(prevTagSize>>8),
+		byte(prevTagSize),
+	)
+	return out
 }

--- a/pkg/flv/header_bytes.go
+++ b/pkg/flv/header_bytes.go
@@ -1,0 +1,23 @@
+package flv
+
+import "encoding/binary"
+
+// NewFileHeaderBytes builds a complete FLV file preamble:
+// 9-byte FLV header + 4-byte PreviousTagSize0.
+func NewFileHeaderBytes() []byte {
+	b := make([]byte, len(FlvHeader)+PrevTagSizeBytes)
+	copy(b, FlvHeader)
+	// PreviousTagSize0 is 0 by FLV spec. The last 4 bytes are already zeroed.
+	return b
+}
+
+func NewTagBytes(tagType byte, data []byte) []byte {
+	b := make([]byte, TagHeaderSize+len(data)+PrevTagSizeBytes)
+	b[0] = tagType
+	b[1] = byte(len(data) >> 16)
+	b[2] = byte(len(data) >> 8)
+	b[3] = byte(len(data))
+	copy(b[TagHeaderSize:], data)
+	binary.BigEndian.PutUint32(b[TagHeaderSize+len(data):], uint32(TagHeaderSize+len(data)))
+	return b
+}

--- a/pkg/flv/header_change_detector.go
+++ b/pkg/flv/header_change_detector.go
@@ -1,0 +1,288 @@
+package flv
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+)
+
+// ErrVideoHeaderChanged signals that the video sequence header (SPS/PPS) has
+// changed and the recording pipeline should rotate to a new file.
+var ErrVideoHeaderChanged = errors.New("video sequence header changed, pipe rotation required")
+
+// FlvHeaderChangedError is a rich error returned by HeaderChangeDetector when
+// the video sequence header changes. It carries the new tag bytes so callers
+// can inject them into the next segment without an extra getter call.
+type FlvHeaderChangedError struct {
+	// VideoHeaderTag is the full FLV tag bytes (TagHeader + Data + PrevTagSize)
+	// for the new video sequence header that triggered rotation.
+	VideoHeaderTag []byte
+	// AudioHeaderTag is the most recently seen full audio sequence header FLV
+	// tag bytes, or nil if no audio sequence header has been observed yet.
+	AudioHeaderTag []byte
+	// TagOffset is the byte offset of the video seq header tag within the
+	// original data slice passed to DetectChange. Split-detector processors
+	// can use this to excise the tag from the data before forwarding it.
+	TagOffset int
+	// TagEnd is the byte offset one past the end of the excised video seq
+	// header region, including the trailing PrevTagSize bytes.
+	TagEnd int
+}
+
+func (e *FlvHeaderChangedError) Error() string {
+	return ErrVideoHeaderChanged.Error()
+}
+
+// Is allows errors.Is(err, ErrVideoHeaderChanged) to return true.
+func (e *FlvHeaderChangedError) Is(target error) bool {
+	return target == ErrVideoHeaderChanged
+}
+
+// HeaderChangeDetector performs byte-level comparison of FLV video (and
+// optionally audio) sequence headers within a raw FLV byte stream.
+//
+// It is stateful: call Reset() when starting a new recording session.
+type HeaderChangeDetector struct {
+	lastVideoHeader []byte
+	lastVideoTag    []byte
+	lastAudioHeader []byte
+	lastAudioTag    []byte
+	pending         []byte
+	buf             *bytes.Buffer // reusable scratch buffer for DetectChange
+	tagBuf          *bytes.Buffer // reusable scratch buffer for building tag+PrevTagSize
+}
+
+// NewHeaderChangeDetector returns a ready-to-use detector.
+func NewHeaderChangeDetector() *HeaderChangeDetector {
+	return &HeaderChangeDetector{
+		buf:    headerDetectorBufferPool.Get(),
+		tagBuf: headerDetectorBufferPool.Get(),
+	}
+}
+
+// Reset clears remembered headers (call at the start of a new recording file).
+func (d *HeaderChangeDetector) Reset() {
+	d.lastVideoHeader = nil
+	d.lastVideoTag = nil
+	d.lastAudioHeader = nil
+	d.lastAudioTag = nil
+	d.pending = nil
+	if d.buf != nil {
+		d.buf.Reset()
+	}
+	if d.tagBuf != nil {
+		d.tagBuf.Reset()
+	}
+}
+
+// Close releases the internal pooled buffers back to the pool and resets all
+// session state. Call this when the detector is no longer needed (e.g. recording
+// stopped). After Close, the detector must not be used again.
+func (d *HeaderChangeDetector) Close() {
+	d.lastVideoHeader = nil
+	d.lastVideoTag = nil
+	d.lastAudioHeader = nil
+	d.lastAudioTag = nil
+	d.pending = nil
+	if d.buf != nil {
+		d.buf.Reset()
+		headerDetectorBufferPool.Put(d.buf)
+		d.buf = nil
+	}
+	if d.tagBuf != nil {
+		d.tagBuf.Reset()
+		headerDetectorBufferPool.Put(d.tagBuf)
+		d.tagBuf = nil
+	}
+}
+
+// SeedVideoHeader pre-seeds the detector with a known video sequence header so
+// it can detect changes from a mid-stream header injected by a prior rotation.
+// Pass the full FLV tag bytes (TagHeader + TagData + PrevTagSize) as stored in
+// FlvHeaderChangedError.VideoHeaderTag. Must be called after Reset().
+func (d *HeaderChangeDetector) SeedVideoHeader(fullTagBytes []byte) {
+	if len(fullTagBytes) <= TagHeaderSize+PrevTagSizeBytes {
+		return
+	}
+	tagData := fullTagBytes[TagHeaderSize : len(fullTagBytes)-PrevTagSizeBytes]
+	d.lastVideoHeader = append([]byte(nil), tagData...)
+	d.lastVideoTag = append([]byte(nil), fullTagBytes...)
+}
+
+// LastVideoHeader returns a copy of the most recently seen video sequence
+// header tag data, or nil if none has been seen yet.
+// Callers can inject this into a new file on pipe rotation.
+func (d *HeaderChangeDetector) LastVideoHeader() []byte {
+	if d.lastVideoHeader == nil {
+		return nil
+	}
+	return append([]byte(nil), d.lastVideoHeader...)
+}
+
+// LastVideoTag returns a copy of the most recently seen video sequence
+// header FLV tag bytes (TagHeader + TagData + PreviousTagSize), or nil.
+func (d *HeaderChangeDetector) LastVideoTag() []byte {
+	if d.lastVideoTag == nil {
+		return nil
+	}
+	return append([]byte(nil), d.lastVideoTag...)
+}
+
+// LastAudioHeader returns a copy of the most recently seen audio sequence
+// header tag data, or nil if none has been seen yet.
+func (d *HeaderChangeDetector) LastAudioHeader() []byte {
+	if d.lastAudioHeader == nil {
+		return nil
+	}
+	return append([]byte(nil), d.lastAudioHeader...)
+}
+
+// LastAudioTag returns a copy of the most recently seen audio sequence header
+// FLV tag bytes (TagHeader + TagData + PreviousTagSize), or nil.
+func (d *HeaderChangeDetector) LastAudioTag() []byte {
+	if d.lastAudioTag == nil {
+		return nil
+	}
+	return append([]byte(nil), d.lastAudioTag...)
+}
+
+// DetectChange scans a raw FLV byte chunk for sequence-header tags.
+// It returns ErrVideoHeaderChanged the first time a video sequence header
+// with different binary content is found compared to the previously seen one.
+// The detector remembers the most recently seen sequence headers, including
+// the new video header that triggered ErrVideoHeaderChanged, so callers can
+// retrieve it after rotation; call Reset() when starting a new recording file.
+func (d *HeaderChangeDetector) DetectChange(data []byte) error {
+	carryLen := len(d.pending)
+	d.buf.Reset()
+	if carryLen > 0 {
+		d.buf.Write(d.pending)
+	}
+	d.buf.Write(data)
+	buf := d.buf.Bytes()
+
+	offset := 0
+
+	// Skip FLV file header + PreviousTagSize0 if this chunk starts with "FLV"
+	if carryLen == 0 && len(buf) >= FlvHeaderSize && buf[0] == 'F' && buf[1] == 'L' && buf[2] == 'V' {
+		offset = FlvHeaderSize + PrevTagSizeBytes
+	}
+
+	for offset+TagHeaderSize < len(buf) {
+		tagType := buf[offset]
+		dataSize := int(buf[offset+1])<<16 | int(buf[offset+2])<<8 | int(buf[offset+3])
+		tagEnd := offset + TagHeaderSize + dataSize
+		tagBoundaryEnd := tagEnd + PrevTagSizeBytes
+
+		if tagBoundaryEnd > len(buf) {
+			break
+		}
+
+		tagData := buf[offset+TagHeaderSize : tagEnd]
+		tagBytes := d.tagWithPrevSize(buf[offset:tagEnd])
+
+		switch tagType {
+		case TagTypeVideo:
+			if err := d.checkVideoHeader(tagData, tagBytes, offset, tagEnd); err != nil {
+				if changed, ok := err.(*FlvHeaderChangedError); ok && carryLen > 0 {
+					changed.TagOffset -= carryLen
+					changed.TagEnd -= carryLen
+					if changed.TagOffset < 0 {
+						changed.TagOffset = 0
+					}
+					if changed.TagEnd < 0 {
+						changed.TagEnd = 0
+					}
+				}
+				d.pending = nil
+				return err
+			}
+		case TagTypeAudio:
+			if err := d.checkAudioHeader(tagData, tagBytes); err != nil {
+				d.pending = nil
+				return err
+			}
+		}
+
+		// Advance: TagHeaderSize + dataSize + PreviousTagSize(4)
+		offset = tagBoundaryEnd
+	}
+
+	if offset < len(buf) {
+		d.pending = append(d.pending[:0], buf[offset:]...)
+	} else {
+		d.pending = nil
+	}
+
+	return nil
+}
+
+// tagWithPrevSize builds a tag+PrevTagSize byte slice into the reusable
+// d.tagBuf and returns d.tagBuf.Bytes(). The returned slice is valid only
+// until the next call to tagWithPrevSize; callers must copy it if they need
+// to retain the data (they all do via append([]byte(nil), ...)).
+func (d *HeaderChangeDetector) tagWithPrevSize(src []byte) []byte {
+	d.tagBuf.Reset()
+	d.tagBuf.Write(src)
+	var sz [PrevTagSizeBytes]byte
+	binary.BigEndian.PutUint32(sz[:], uint32(len(src)))
+	d.tagBuf.Write(sz[:])
+	return d.tagBuf.Bytes()
+}
+
+// checkVideoHeader inspects a video tag's payload for AVC sequence header
+// changes. Returns ErrVideoHeaderChanged on a binary diff.
+func (d *HeaderChangeDetector) checkVideoHeader(tagData []byte, tagBytes []byte, tagOffset int, tagEnd int) error {
+	if len(tagData) < 2 {
+		return nil
+	}
+
+	// tagData[0]: FrameType(4 bits) | CodecID(4 bits)
+	// tagData[1]: AVCPacketType — only meaningful for AVC (CodecID == 7)
+	codecID := tagData[0] & 0x0F
+	if codecID != 7 { // not AVC/H.264 — skip
+		return nil
+	}
+
+	const avcSequenceHeader = 0x00
+	if tagData[1] != avcSequenceHeader {
+		return nil
+	}
+
+	if d.lastVideoHeader == nil {
+		// First time: remember and continue.
+		d.lastVideoHeader = append([]byte(nil), tagData...)
+		d.lastVideoTag = append([]byte(nil), tagBytes...)
+		return nil
+	}
+
+	if !bytes.Equal(d.lastVideoHeader, tagData) {
+		// Header changed — update state so the caller can retrieve the new
+		// header via LastVideoHeader() after handling the error.
+		d.lastVideoHeader = append([]byte(nil), tagData...)
+		d.lastVideoTag = append([]byte(nil), tagBytes...)
+		return &FlvHeaderChangedError{
+			VideoHeaderTag: append([]byte(nil), tagBytes...),
+			AudioHeaderTag: d.LastAudioTag(),
+			TagOffset:      tagOffset,
+			TagEnd:         tagEnd + PrevTagSizeBytes,
+		}
+	}
+
+	return nil
+}
+
+// checkAudioHeader records AAC sequence header tag bytes.
+func (d *HeaderChangeDetector) checkAudioHeader(tagData []byte, tagBytes []byte) error {
+	if len(tagData) < 2 {
+		return nil
+	}
+	// tagData[0] >> 4 == 10 → AAC; tagData[1] == 0 → AAC sequence header
+	if (tagData[0]>>4) != 10 || tagData[1] != 0x00 {
+		return nil
+	}
+	// Always update — both tagData and full tag bytes.
+	d.lastAudioHeader = append([]byte(nil), tagData...)
+	d.lastAudioTag = append([]byte(nil), tagBytes...)
+	return nil
+}

--- a/pkg/flv/header_writer.go
+++ b/pkg/flv/header_writer.go
@@ -1,0 +1,47 @@
+package flv
+
+// FlvHeaderWriter prepends a FLV file preamble and optional sequence-header
+// tags to a data chunk. It is stateless; the caller (typically a processor)
+// is responsible for ensuring Prepend is called only once per file segment.
+type FlvHeaderWriter struct {
+	// VideoHeaderTag is an optional complete FLV tag bytes
+	// (TagHeader + Data + PrevTagSize) for the video sequence header.
+	VideoHeaderTag []byte
+	// AudioHeaderTag is an optional complete FLV tag bytes
+	// (TagHeader + Data + PrevTagSize) for the audio sequence header.
+	AudioHeaderTag []byte
+}
+
+func normalizeTagTimestamp(tag []byte) []byte {
+	if len(tag) == 0 {
+		return nil
+	}
+	out := append([]byte(nil), tag...)
+	if len(out) >= TagHeaderSize {
+		// Always start injected sequence-header tags from timestamp 0 in a new segment.
+		out[4] = 0
+		out[5] = 0
+		out[6] = 0
+		out[7] = 0
+	}
+	return out
+}
+
+// Prepend merges the FLV file header, optional video/audio sequence-header
+// tags, and data into one byte slice.
+func (w *FlvHeaderWriter) Prepend(data []byte) []byte {
+	fileHeader := NewFileHeaderBytes() // 9-byte FLV magic + 4-byte PrevTagSize0
+	vTag := normalizeTagTimestamp(w.VideoHeaderTag)
+	aTag := normalizeTagTimestamp(w.AudioHeaderTag)
+	size := len(fileHeader) + len(vTag) + len(aTag) + len(data)
+	result := make([]byte, 0, size)
+	result = append(result, fileHeader...)
+	if len(vTag) > 0 {
+		result = append(result, vTag...)
+	}
+	if len(aTag) > 0 {
+		result = append(result, aTag...)
+	}
+	result = append(result, data...)
+	return result
+}

--- a/pkg/flv/realtime_fixer.go
+++ b/pkg/flv/realtime_fixer.go
@@ -1,4 +1,4 @@
-﻿package flv
+package flv
 
 import (
 	"bytes"
@@ -10,24 +10,23 @@ import (
 // =====================================================
 
 type RealtimeFixer struct {
-	mu             sync.Mutex
-	tsStore        *TimestampStore
-	buffer         *bytes.Buffer
-	headerWritten  bool
-	pendingTags    []*Tag
-	dedupCache     *DedupCache // 🔥 新增:  去重緩存
-	dupCount       int64       // 🔥 新增: 重複計數
-	lastDedupClean int32       // timestamp of last dedup clean
+	mu                sync.Mutex
+	tsStore           *TimestampStore
+	buffer            *bytes.Buffer
+	sourceHeaderOK    bool
+	isRotationSegment bool        // set by ResetTimestampStore; rotation segments have no FLV file header
+	dedupCache        *DedupCache // 🔥 新增:  去重緩存
+	dupCount          int64       // 🔥 新增: 重複計數
+	lastDedupClean    int32       // timestamp of last dedup clean
 }
 
 func NewRealtimeFixer() *RealtimeFixer {
 	return &RealtimeFixer{
-		tsStore:       &TimestampStore{FirstChunk: true},
-		buffer:        byteBufferPool.Get(), // 🔥 優化: 從 pool 取得
-		headerWritten: false,
-		pendingTags:   make([]*Tag, 0, 32),
-		dedupCache:    NewDedupCache(MaxDedupCacheSize, DedupWindowMs), // 🔥 初始化去重
-		dupCount:      0,
+		tsStore:        &TimestampStore{FirstChunk: true},
+		buffer:         realtimeBufferPool.Get(), // 🔥 優化: 從 pool 取得
+		sourceHeaderOK: false,
+		dedupCache:     NewDedupCache(MaxDedupCacheSize, DedupWindowMs), // 🔥 初始化去重
+		dupCount:       0,
 	}
 }
 
@@ -48,19 +47,26 @@ func (rf *RealtimeFixer) Fix(input []byte) ([]byte, error) {
 	rf.buffer.Write(input)
 
 	// 🔥 優化: 從 pool 取得輸出 buffer
-	output := byteBufferPool.Get()
+	output := realtimeBufferPool.Get()
 	output.Reset()
 
-	// Write FLV header once
-	if !rf.headerWritten && rf.buffer.Len() >= 9 {
-		header := rf.buffer.Next(9)
-		if !bytes.Equal(header[:3], []byte{'F', 'L', 'V'}) {
+	// Consume the FLV file header once.
+	// Rotation segments start at a tag boundary (no file header), so skip straight through.
+	// Segment 0 must begin with FLV magic bytes or the stream is invalid.
+	needsHeaderCheck := !rf.sourceHeaderOK && rf.buffer.Len() >= FlvHeaderSize
+	if needsHeaderCheck {
+		isFlvMagic := bytes.Equal(rf.buffer.Bytes()[:3], []byte{'F', 'L', 'V'})
+		switch {
+		case isFlvMagic:
+			rf.buffer.Next(FlvHeaderSize) // consume 9-byte header; PrevTagSize0 stays for tag loop
+		case rf.isRotationSegment:
+			// carried bytes start at a tag boundary — nothing to consume
+		default:
+			output.Reset()
+			realtimeBufferPool.Put(output)
 			return nil, ErrNotFlvFile
 		}
-		output.Write(header)
-		// Write initial PreviousTagSize0 = 0
-		output.Write([]byte{0, 0, 0, 0})
-		rf.headerWritten = true
+		rf.sourceHeaderOK = true
 	}
 
 	headerBytes := headerBytesPool.GetBytes()
@@ -79,14 +85,14 @@ func (rf *RealtimeFixer) Fix(input []byte) ([]byte, error) {
 		// Peek tag header
 		// Not enough bytes for header yet: rebuild PrevTagSize + remaining bytes safely.
 		if rf.buffer.Len() < TagHeaderSize {
-			tmp := byteBufferPool.Get()
+			tmp := realtimeBufferPool.Get()
 			tmp.Reset()
 			tmp.Write([]byte{0, 0, 0, 0}) // PrevTagSize
 			tmp.Write(rf.buffer.Bytes())
 			rf.buffer.Reset()
 			rf.buffer.Write(tmp.Bytes())
 			tmp.Reset()
-			byteBufferPool.Put(tmp)
+			realtimeBufferPool.Put(tmp)
 			break
 		}
 
@@ -99,7 +105,7 @@ func (rf *RealtimeFixer) Fix(input []byte) ([]byte, error) {
 		// Check if we have complete tag data
 		if rf.buffer.Len() < int(dataSize) {
 			// Need more bytes: reconstruct PrevTagSize + header + current remainder
-			tempBuf := byteBufferPool.Get()
+			tempBuf := realtimeBufferPool.Get()
 			tempBuf.Reset()
 			tempBuf.Write([]byte{0, 0, 0, 0}) // PrevTagSize
 			tempBuf.Write(headerBytes)        // use headerBytes while valid
@@ -109,7 +115,7 @@ func (rf *RealtimeFixer) Fix(input []byte) ([]byte, error) {
 			rf.buffer.Write(tempBuf.Bytes())
 
 			tempBuf.Reset()
-			byteBufferPool.Put(tempBuf)
+			realtimeBufferPool.Put(tempBuf)
 			break
 		}
 
@@ -158,6 +164,8 @@ func (rf *RealtimeFixer) Fix(input []byte) ([]byte, error) {
 
 		// Write fixed tag
 		if err := writeTagOptimized(output, tag); err != nil {
+			output.Reset()
+			realtimeBufferPool.Put(output)
 			return nil, err
 		}
 
@@ -183,19 +191,48 @@ func (rf *RealtimeFixer) Fix(input []byte) ([]byte, error) {
 	copy(result, output.Bytes())
 
 	output.Reset()
-	byteBufferPool.Put(output)
+	realtimeBufferPool.Put(output)
 
 	return result, nil
 }
 
 // 🔥 優化:  釋放資源
+// ResetTimestampStore resets the timestamp offset for a new segment.
+// This should be called when rotating to a new segment file so that
+// the new segment's timestamps start from 0 instead of continuing
+// from the previous segment's time range.
+func (rf *RealtimeFixer) ResetTimestampStore() {
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+
+	if rf.tsStore != nil {
+		rf.tsStore.Reset()
+	}
+	// Mark as rotation segment so Fix() skips the FLV file header check.
+	// Rotation segments start with split-detector-injected carried bytes, not a FLV header.
+	rf.isRotationSegment = true
+	rf.sourceHeaderOK = false
+}
+
+// ResetDedupCache clears the deduplication cache, which can be useful when starting a new segment to avoid false positives from old tags.
+// currently not used because the dedup cache automatically expires old entries based on timestamp, but can be called manually if needed (e.g. on segment rotation).
+func (rf *RealtimeFixer) ResetDedupCache() {
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+
+	if rf.dedupCache != nil {
+		rf.dedupCache.Reset()
+	}
+
+}
+
 func (rf *RealtimeFixer) Close() {
 	rf.mu.Lock()
 	defer rf.mu.Unlock()
 
 	if rf.buffer != nil {
 		rf.buffer.Reset()
-		byteBufferPool.Put(rf.buffer)
+		realtimeBufferPool.Put(rf.buffer)
 		rf.buffer = nil
 	}
 
@@ -207,8 +244,7 @@ func (rf *RealtimeFixer) Close() {
 	if rf.tsStore != nil {
 		rf.tsStore.Reset()
 	}
-	rf.headerWritten = false
-	rf.pendingTags = nil
+	rf.sourceHeaderOK = false
 }
 
 // compactBufferIfNeeded shrinks rf.buffer when capacity is much larger than used length.
@@ -221,7 +257,7 @@ func (rf *RealtimeFixer) compactBufferIfNeeded() {
 
 	// Heuristic: if buffer is very large (>> MaxBufferSize) and largely empty, shrink it.
 	if c > MaxBufferSize && l <= c/4 {
-		newBuf := byteBufferPool.Get()
+		newBuf := realtimeBufferPool.Get()
 		newBuf.Reset()
 		if l > 0 {
 			newBuf.Write(rf.buffer.Bytes())
@@ -229,7 +265,7 @@ func (rf *RealtimeFixer) compactBufferIfNeeded() {
 		old := rf.buffer
 		rf.buffer = newBuf
 		// Return old to pool (Put only keeps buffers <= maxCap; otherwise allow GC)
-		byteBufferPool.Put(old)
+		realtimeBufferPool.Put(old)
 	}
 }
 func (rf *RealtimeFixer) fixTimestamp(tag *Tag) {
@@ -255,6 +291,11 @@ func (rf *RealtimeFixer) fixTimestamp(tag *Tag) {
 
 	// Apply offset
 	tag.Timestamp -= ts.CurrentOffset
+	if tag.Timestamp < 0 {
+		// FLV timestamp is unsigned in file format; negative values would be
+		// serialized as huge wraparound numbers (e.g. 4294967s start time).
+		tag.Timestamp = 0
+	}
 
 	// Calculate next target
 	ts.NextTimestampTarget = CalculateNextTarget(tag)

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -74,6 +74,8 @@ func (p *Pipe[T]) process(ctx context.Context, tp *ProcessorInfo[T], item T) (T,
 		switch tp.errorStrategy {
 		case StopOnError:
 			return item, err
+		case ReturnNextOnError:
+			return next, err
 		case ContinueOnError:
 			tp.logger.Warnf("continuing despite error in processor %s: %v", tp.name, err)
 			return item, nil

--- a/pkg/pipeline/processor.go
+++ b/pkg/pipeline/processor.go
@@ -13,6 +13,7 @@ type ErrorStrategy int
 
 const (
 	StopOnError ErrorStrategy = iota
+	ReturnNextOnError
 	ContinueOnError
 	RetryOnError
 )

--- a/pkg/pool/buffer.go
+++ b/pkg/pool/buffer.go
@@ -5,29 +5,82 @@ import (
 	"sync"
 )
 
-type BufferPool struct {
-	pool   sync.Pool
-	maxCap int
+type BufferPoolMode int
+
+const (
+	// BufferPoolModeSoft uses sync.Pool semantics (default behavior).
+	BufferPoolModeSoft BufferPoolMode = iota
+	// BufferPoolModeBounded keeps at most BoundedCapacity buffers in a fixed queue.
+	BufferPoolModeBounded
+)
+
+type BufferPoolConfig struct {
+	mode            BufferPoolMode
+	boundedCapacity int
 }
 
-func NewBufferPool(initialCap, maxCap int) *BufferPool {
+type BufferPoolOption func(*BufferPoolConfig)
+
+type BufferPool struct {
+	pool    sync.Pool
+	maxCap  int
+	mode    BufferPoolMode
+	bounded chan *bytes.Buffer
+	newBuf  func() *bytes.Buffer
+}
+
+func NewBufferPool(initialCap, maxCap int, options ...BufferPoolOption) *BufferPool {
 	if initialCap < 0 {
 		initialCap = 0
 	}
 	if maxCap < initialCap {
 		maxCap = initialCap
 	}
-	return &BufferPool{
-		pool: sync.Pool{
-			New: func() any {
-				return bytes.NewBuffer(make([]byte, 0, initialCap))
-			},
-		},
-		maxCap: maxCap,
+
+	cfg := BufferPoolConfig{
+		mode:            BufferPoolModeSoft,
+		boundedCapacity: 128,
 	}
+	for _, opt := range options {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
+	newBuf := func() *bytes.Buffer {
+		return bytes.NewBuffer(make([]byte, 0, initialCap))
+	}
+
+	bp := &BufferPool{
+		maxCap: maxCap,
+		mode:   cfg.mode,
+		newBuf: newBuf,
+	}
+
+	if cfg.mode == BufferPoolModeBounded {
+		bp.bounded = make(chan *bytes.Buffer, cfg.boundedCapacity)
+		return bp
+	}
+
+	bp.pool = sync.Pool{
+		New: func() any {
+			return newBuf()
+		},
+	}
+
+	return bp
 }
 
 func (bp *BufferPool) Get() *bytes.Buffer {
+	if bp.mode == BufferPoolModeBounded {
+		select {
+		case buf := <-bp.bounded:
+			return buf
+		default:
+			return bp.newBuf()
+		}
+	}
+
 	return bp.pool.Get().(*bytes.Buffer)
 }
 
@@ -38,7 +91,35 @@ func (bp *BufferPool) Put(buf *bytes.Buffer) {
 	// Only pool buffers that haven't grown too large
 	if buf.Cap() <= bp.maxCap {
 		buf.Reset()
+		if bp.mode == BufferPoolModeBounded {
+			select {
+			case bp.bounded <- buf:
+			default:
+				// Queue is full; let buffer be garbage collected.
+			}
+			return
+		}
 		bp.pool.Put(buf)
 	}
 	// Otherwise, let it be garbage collected
+}
+
+func WithBoundedMode(enabled bool) BufferPoolOption {
+	return func(c *BufferPoolConfig) {
+		if enabled {
+			c.mode = BufferPoolModeBounded
+		} else {
+			c.mode = BufferPoolModeSoft
+		}
+	}
+}
+
+func WithBoundedCapacity(capacity int) BufferPoolOption {
+	return func(c *BufferPoolConfig) {
+		if capacity <= 0 {
+			c.boundedCapacity = 128
+		} else {
+			c.boundedCapacity = capacity
+		}
+	}
 }

--- a/pkg/pool/buffer_test.go
+++ b/pkg/pool/buffer_test.go
@@ -1,0 +1,50 @@
+package pool
+
+import "testing"
+
+func TestBufferPoolSoftModeDefault(t *testing.T) {
+	bp := NewBufferPool(16, 64)
+
+	buf := bp.Get()
+	if buf == nil {
+		t.Fatal("expected non-nil buffer")
+	}
+	buf.WriteString("abc")
+	bp.Put(buf)
+
+	buf2 := bp.Get()
+	if buf2 == nil {
+		t.Fatal("expected non-nil buffer on second get")
+	}
+	if buf2.Len() != 0 {
+		t.Fatalf("expected reset buffer len 0, got %d", buf2.Len())
+	}
+}
+
+func TestBufferPoolBoundedDropsWhenFull(t *testing.T) {
+	bp := NewBufferPool(
+		16,
+		64,
+		WithBoundedMode(true),
+		WithBoundedCapacity(1),
+	)
+
+	b1 := bp.Get()
+	b2 := bp.Get()
+	if b1 == nil || b2 == nil {
+		t.Fatal("expected non-nil buffers")
+	}
+
+	bp.Put(b1)
+	bp.Put(b2) // should be dropped because bounded queue is full
+
+	g1 := bp.Get()
+	if g1 == nil {
+		t.Fatal("expected non-nil buffer from bounded pool")
+	}
+	// Queue capacity is 1, so second Get must allocate/new and still be non-nil.
+	g2 := bp.Get()
+	if g2 == nil {
+		t.Fatal("expected non-nil second buffer even when queue empty")
+	}
+}


### PR DESCRIPTION
resolve #5 
---
現在我對整個 codebase 有了全面了解，可以幫你規劃詳細的變更。

---

## 變更規劃

### 現狀分析

目前 `fix/5` 分支的分割流程：
1. `FlvStreamFixer` → 解析/輸出固定 FLV（**自己在輸出流中寫入 FLV file header**）
2. `FlvHeaderSplitDetector` → 偵測 header 變更，把 `videoHeaderTag` **硬塞進 data bytes** 回傳
3. `BufferedStreamWriter(initData)` → Open 時寫入 `initData`（`FLV_FILE_HEADER + videoHeaderTag`）
4. `recorder.rotate()` 中用 `mergeInitDataWithFlvHeader()` 手動拼湊 bytes 傳給 writer

**問題**：職責混亂、header 注入方式 hacky、無法同時注入 audio header、`initData` 概念不清晰。

---

### 整體架構目標

新 pipeline 結構（每個 segment 都獨立建立）：

```
FlvStreamFixer → FlvHeaderSplitDetector → FlvHeaderWriter(videoHdr?, audioHdr?) → BufferedStreamWriter
```

- **Segment 0**：`FlvHeaderWriter(nil, nil)` — 只寫 FLV 9-byte file header + PrevTagSize0
- **Segment N**：`FlvHeaderWriter(videoHdr, audioHdr)` — 寫 FLV file header + video sequence header tag + audio sequence header tag

---

### 具體變更清單

---

#### 1. `pkg/flv/header_change_detector.go` — 豐富 error 型別，攜帶 headers

**變更點：**
- 新增 `FlvHeaderChangedError` struct，實現 `error` 介面並透過 `Is()` 相容現有 `ErrVideoHeaderChanged`
- 在 `HeaderChangeDetector` 新增 `lastAudioTag []byte` 欄位（儲存完整 tag bytes，對應現有 `lastVideoTag`）
- `checkAudioHeader` 同時儲存完整 audio tag bytes（用 `withPrevTagSize()`）
- `DetectChange()` 回傳 `*FlvHeaderChangedError` 而非 `ErrVideoHeaderChanged`

```go
// NEW: 攜帶 headers 的 error 型別
type FlvHeaderChangedError struct {
    VideoHeaderTag []byte // 完整 video sequence header FLV tag bytes（含 PrevTagSize）
    AudioHeaderTag []byte // 完整 audio sequence header FLV tag bytes（含 PrevTagSize），可能為 nil
}

func (e *FlvHeaderChangedError) Error() string {
    return "video sequence header changed, pipe rotation required"
}

// 確保 errors.Is(err, ErrVideoHeaderChanged) 仍然成立
func (e *FlvHeaderChangedError) Is(target error) bool {
    return target == ErrVideoHeaderChanged
}
```

`checkVideoHeader` 改為：
```go
return &FlvHeaderChangedError{
    VideoHeaderTag: d.lastVideoTag,    // 已更新的新 header
    AudioHeaderTag: d.lastAudioTag,    // 當前已知的 audio header
}
```

---

#### 2. `pkg/flv/header_writer.go` — 新建 FlvHeaderWriter

從 `realtime_fixer.go` 的 FLV file header 寫入邏輯抽出，成為獨立型別：

```go
package flv

// FlvHeaderWriter 負責在新 FLV 文件開頭寫入必要的 headers。
// 它是無狀態的，每個 segment 實例化一次。
type FlvHeaderWriter struct {
    VideoHeaderTag []byte // 可選：完整 video sequence header tag bytes（含 PrevTagSize）
    AudioHeaderTag []byte // 可選：完整 audio sequence header tag bytes（含 PrevTagSize）
}

// Prepend 把 FLV file header、可選的 video/audio sequence header tags
// 以及原始 data 合併成一個 byte slice，供 processor 在第一次 Process 時使用。
func (w *FlvHeaderWriter) Prepend(data []byte) []byte {
    fileHeader := NewFileHeaderBytes() // 9-byte FLV magic + PrevTagSize0(4 bytes)
    size := len(fileHeader) + len(w.VideoHeaderTag) + len(w.AudioHeaderTag) + len(data)
    result := make([]byte, 0, size)
    result = append(result, fileHeader...)
    if len(w.VideoHeaderTag) > 0 {
        result = append(result, w.VideoHeaderTag...)
    }
    if len(w.AudioHeaderTag) > 0 {
        result = append(result, w.AudioHeaderTag...)
    }
    result = append(result, data...)
    return result
}
```

> **注意**：`NewFileHeaderBytes()` 需要在 `pkg/flv` 中新增（或確認已有對應 function），生成標準 FLV 9-byte header + `PrevTagSize0 = 0` 共 13 bytes。

---

#### 3. `pkg/flv/realtime_fixer.go` — 移除 FLV file header 寫入

**變更點：**
- `headerWritten` 重命名為 `headerSkipped`（語意更準確）
- `Fix()` 中原本寫入 FLV file header 的代碼，改為**只跳過（skip），不輸出**：

```go
// 舊：
if !rf.headerWritten && rf.buffer.Len() >= 9 {
    header := rf.buffer.Next(9)
    // ... 驗證 ...
    output.Write(header)           // ❌ 移除
    output.Write([]byte{0,0,0,0}) // ❌ 移除
    rf.headerWritten = true
}

// 新：
if !rf.headerSkipped && rf.buffer.Len() >= FlvHeaderSize {
    header := rf.buffer.Next(FlvHeaderSize)
    if !bytes.Equal(header[:3], []byte{'F', 'L', 'V'}) {
        return nil, ErrNotFlvFile
    }
    // 跳過 PrevTagSize0
    if rf.buffer.Len() >= PrevTagSizeBytes {
        rf.buffer.Next(PrevTagSizeBytes)
    }
    rf.headerSkipped = true
}
```

這樣 `RealtimeFixer` 的輸出就只有純 FLV tags，不再含 file header。

---

#### 4. `internal/processors/flv_header_writer.go` — 新建 processor

```go
package processors

import (
    "context"
    "sync"

    "github.com/eric2788/bilirec/pkg/flv"
    "github.com/eric2788/bilirec/pkg/pipeline"
    "github.com/sirupsen/logrus"
)

type flvHeaderWriterProcessor struct {
    writer  *flv.FlvHeaderWriter
    mu      sync.Mutex
    written bool
}

// NewFlvHeaderWriter 建立一個在第一個 data chunk 前面注入 FLV headers 的 processor。
// videoHeaderTag 和 audioHeaderTag 可以為 nil（表示只寫 FLV file header）。
func NewFlvHeaderWriter(videoHeaderTag, audioHeaderTag []byte) *pipeline.ProcessorInfo[[]byte] {
    return pipeline.NewProcessorInfo(
        "flv-header-writer",
        &flvHeaderWriterProcessor{
            writer: &flv.FlvHeaderWriter{
                VideoHeaderTag: videoHeaderTag,
                AudioHeaderTag: audioHeaderTag,
            },
        },
    )
}

func (p *flvHeaderWriterProcessor) Open(ctx context.Context, log *logrus.Entry) error {
    p.written = false
    return nil
}

func (p *flvHeaderWriterProcessor) Process(ctx context.Context, log *logrus.Entry, data []byte) ([]byte, error) {
    p.mu.Lock()
    defer p.mu.Unlock()
    if p.written {
        return data, nil
    }
    p.written = true
    return p.writer.Prepend(data), nil
}

func (p *flvHeaderWriterProcessor) Close() error {
    return nil
}
```

---

#### 5. `internal/processors/flv_header_split_detector.go` — 移除 seed 拼接，改用 error 攜帶 headers

**變更點：**
- `Process()` 不再手動把 `videoHeaderTag` 塞進 data bytes
- 直接回傳原始 `(data, err)`，由 recorder 從 `*flv.FlvHeaderChangedError` 取 headers

```go
func (p *flvHeaderSplitDetectorProcessor) Process(ctx context.Context, log *logrus.Entry, data []byte) ([]byte, error) {
    err := p.detector.DetectChange(data)
    if err == nil {
        return data, nil
    }
    if errors.Is(err, flv.ErrVideoHeaderChanged) {
        log.Infof("🔀 video sequence header changed (SPS/PPS diff), triggering pipe rotation")
        // 不再拼 seed，直接回傳原 data 和 error（error 本身攜帶 headers）
        return data, err
    }
    return data, err
}
```

> 這樣 `rev()` 回傳的 `(result, ErrShouldCut)` 中，`result` 就是原始 data（未含 header），而 headers 在 error 中。

---

#### 6. `internal/processors/buffered_stream_writer.go` — 移除 `initData`

**變更點：**
- 移除 `initData []byte` 欄位
- `NewBufferedStreamWriter()` 不再接受 `initData` 參數
- `Open()` 移除 `initData` 寫入邏輯

```go
// 舊簽名：
func NewBufferedStreamWriter(path string, bufferSize int, initData []byte) *pipeline.ProcessorInfo[[]byte]

// 新簽名：
func NewBufferedStreamWriter(path string, bufferSize int) *pipeline.ProcessorInfo[[]byte]
```

---

#### 7. `internal/services/recorder/recorder.go` — 整合新 pipeline

**變更點：**

**`rotate()` 函數：**
- 新增 `var videoHdr, audioHdr []byte`（初始為 nil）
- 每次 loop 建立 pipeline 時使用 `NewFlvHeaderWriter(videoHdr, audioHdr)`
- 從 `*flv.FlvHeaderChangedError` 取 headers（不再需要 `initData []byte` 或 `mergeInitDataWithFlvHeader()`）
- `rev()` 回傳的 data（`b`）可直接丟棄（因為 headers 在 error 中，data 需要寫入下一個 segment 但當前 `result` 包含觸發點的 data，需確認是否要作為下一 segment 首個 chunk）

```go
func (r *Service) rotate(roomId int, ch <-chan []byte, info *Info, ctx context.Context) error {
    l := logger.WithField("room", roomId)
    segment := 0
    var videoHdr, audioHdr []byte // nil for segment 0

    for {
        outputPath, err := r.rotateFilePath(info, segment)
        if err != nil {
            return fmt.Errorf("cannot prepare file path: %v", err)
        }
        info.SetOutputPath(outputPath)

        pipe := pipeline.New(
            processors.NewFlvStreamFixer(),
            processors.NewFlvHeaderSplitDetector(),
            processors.NewFlvHeaderWriter(videoHdr, audioHdr), // ← 新增
            processors.NewBufferedStreamWriter(info.OutputPath(), config.ReadOnly.LiveStreamWriterBufferSize()), // ← 移除 initData
        )

        r.writtingFiles.Add(filepath.Base(info.OutputPath()))

        startCtx, startCancel := context.WithTimeout(ctx, 10*time.Second)
        if err := pipe.Open(startCtx); err != nil {
            startCancel()
            return fmt.Errorf("cannot open pipeline: %v", err)
        }
        startCancel()

        r.pipes.Store(roomId, pipe)

        // 注意：不再需要 r.st.Flush(initData) — header 注入由 FlvHeaderWriter 處理
        firstData, err := r.rev(roomId, ch, info, ctx, pipe)
        if err != nil {
            l.Errorf("error writing data to file: %v", err)
            if errors.Is(err, ErrShouldCut) {
                // 從 error 取 headers（不再從 result bytes 取）
                var headerChanged *flv.FlvHeaderChangedError
                if errors.As(err, &headerChanged) {
                    videoHdr = headerChanged.VideoHeaderTag
                    audioHdr = headerChanged.AudioHeaderTag
                }
                // firstData 是觸發 rotate 的那個 chunk，需要在下個 segment 重新處理
                // 可考慮保存為 pendingData 在下個 segment 首先注入
                _ = firstData // 視乎是否需要重放
                segment++
                continue
            } else if err == processors.ErrNotFlvFile {
                // ... 現有邏輯不變
            }
        }
        break
    }
    return nil
}
```

**移除 `mergeInitDataWithFlvHeader()`** — 此函數已無用。

**`rev()` 函數調整：**
- 回傳簽名保持 `([]byte, error)`
- 當 `ErrShouldCut` 時，`result` 是當前 chunk 的原始 data，可選擇是否要在下個 segment 重放

---

### 待驗證的可行性問題

1. **觸發 rotate 的那個 chunk（`firstData`）**：當 header 變更被偵測到時，`DetectChange()` 是在 data chunk 的**中途**偵測到的。這個 chunk 可能同時含有 header 變更 tag 和後續 tags。需要確認：
   - 是否需要把這個 chunk 的剩餘 tags 重放到下個 segment？
   - 目前舊代碼是把整個 `data` 加上 `videoHeaderTag` 合成 `seed` 傳到下個 segment，邏輯上是對的（但 header tag 會出現兩次 — 一次在舊文件末，一次作為新文件 `initData`）
   - **建議**：`rev()` 回傳的 `firstData`（即觸發 rotate 的 chunk）應該作為下個 segment 的 pending first chunk 傳入 pipeline

2. **`RealtimeFixer` 對後續 segments 的 FLV header 跳過邏輯**：Segment N 的 `RealtimeFixer` 是全新實例，`headerSkipped = false`。但 HTTP-FLV stream 在中途不會重新發 FLV file header，所以後續 chunks 不以 `FLV` magic 開頭，`headerSkipped` 永遠不會被設為 `true`。這是正確的行為，但要確認 `rf.buffer.Len() >= FlvHeaderSize` 的前置條件不會在中途誤觸發。

3. **Audio header 的時機**：`HeaderChangeDetector` 目前只在 video header 變更時 trigger，audio header 只是被記住。`FlvHeaderChangedError.AudioHeaderTag` 可能是 nil（如果 audio header 從未見過），需要在 `FlvHeaderWriter` 中做好 nil check（已在設計中）。

---

### 文件變更摘要

| 文件 | 操作 | 主要變更 |
|------|------|---------|
| `pkg/flv/header_change_detector.go` | ✏️ 修改 | 新增 `FlvHeaderChangedError` struct；新增 `lastAudioTag` 欄位；`DetectChange()` 回傳 rich error |
| `pkg/flv/header_writer.go` | 🆕 新建 | `FlvHeaderWriter` struct，`Prepend()` method |
| `pkg/flv/realtime_fixer.go` | ✏️ 修改 | 移除 FLV file header 寫出，只 skip 輸入中的 header |
| `internal/processors/flv_header_writer.go` | 🆕 新建 | `flvHeaderWriterProcessor` pipeline wrapper |
| `internal/processors/flv_header_split_detector.go` | ✏️ 修改 | 移除 seed 拼接，直接回傳 `(data, err)` |
| `internal/processors/buffered_stream_writer.go` | ✏️ 修改 | 移除 `initData` 欄位和參數 |
| `internal/services/recorder/recorder.go` | ✏️ 修改 | `rotate()` 使用新 pipeline；從 `FlvHeaderChangedError` 取 headers；移除 `mergeInitDataWithFlvHeader()` |