### PR TITLE
Add perf comparison test runner scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Android 模式下会先注入一组移动端默认值（如 `HOST=127.0.0.1`、`
 | `DOWNLOAD_BUFFER_SIZE` | 文件下载 / 导出时使用的缓冲区大小（字节） | `5242880` (5 MB) |
 | `STREAM_WRITER_BUFFER_SIZE` | 流写入器（写入文件）缓冲区大小（字节） | `1048576` (1 MB) |
 | `READ_STREAM_BYTES_POOL_SIZE` | 读取直播流时使用的字节池单块大小（字节）；`FLV` / `HLS` 共用，建议与常见 chunk 大小一致 | `524288` (512 KB) |
+| `READ_STREAM_BYTES_POOL_SIZE_HIGH` | 2K/4K 高画质 **FLV 读侧**池块大小（字节）；按实际流 `qn` 达到高画质时启用（懒加载） | `1048576` (1 MB) |
 | `READ_STREAM_CHAN_BUFFER_SIZE` | 读取直播流时的通道缓冲区大小（chunk 数）；更大值可容忍网络/写入短时抖动，但会增加在途内存 | `16` |
 | `PERF_PRESET` | 性能行为预设：`low-cpu`（默认，偏向更低 CPU）/ `low-mem`（偏向更低内存平台） | `low-cpu` |
 | `LIVE_STREAM_WRITER_BUFFER_SIZE` | 实时流写入缓冲区（用于直播录制或实时下载，字节）；更大的值减少 flush 频率，降低 SD 卡磨损 | `8388608` (8 MB) |
@@ -294,6 +295,7 @@ Android 模式下会先注入一组移动端默认值（如 `HOST=127.0.0.1`、`
 | `LIVE_STREAM_WRITER_FLUSH_PERIOD_SECS` | 实时流写入器执行周期性 `flush` 的周期（秒）；值越大 flush 频率越低，越有利于减少 SD 卡写入频次 | `10` |
 | `LIVE_STREAM_WRITER_CHAN_BUFFER_SIZE` | 实时流写入器通道缓冲区大小（数据块数）；更大的值可容忍写入延迟突变，但会增加内存占用 | `64` |
 | `LIVE_STREAM_WRITER_BYTES_POOL_SIZE` | 实时流写入器内存池的单个缓冲区大小（字节）；应与实际流 chunk 大小相匹配 | `524288` (512 KB) |
+| `LIVE_STREAM_WRITER_BYTES_POOL_SIZE_HIGH` | 2K/4K 高画质写侧池块大小（字节）；按实际流 `qn` 达到高画质时启用（懒加载） | `1048576` (1 MB) |
 | `SKIP_SMALL_FLUSH_THRESHOLD` | 启用 `SKIP_SMALL_FLUSH` 后，延迟创建文件并缓存内存的阈值（字节）；达到阈值后才开始落盘。该值独立于 `LIVE_STREAM_WRITER_BUFFER_SIZE` | `1048576` (1 MB) |
 | `SKIP_SMALL_FLUSH` | 启用 microSD 磨损保护：在达到 `SKIP_SMALL_FLUSH_THRESHOLD` 之前仅缓存内存，不创建文件 | `true` |
 | `SEQUENTIAL_WRITE` | 启用全局 flush 锁以序列化多路录制的写入操作；仅在多路并发录制写入同一物理磁盘时建议启用，可显著降低 I/O 峰值 | `true` |
@@ -317,6 +319,21 @@ Android 模式下会先注入一组移动端默认值（如 `HOST=127.0.0.1`、`
   - 在 `low-mem` 下，若进入恢复失败阶段，会临时降到 `1`，恢复后自动回到 preset 对应值。
 - **启动日志**  
   - 启动时会输出当前性能预设，便于线上排查（例如：`性能预设：low-mem`）。
+
+### 2K/4K 双池懒加载（按 qn 自动分流）
+
+当系统检测到实际流质量 `qn >= 20000`（例如 2K/4K）时，会启用高画质路径：
+
+- 写侧：`LIVE_STREAM_WRITER_BYTES_POOL_SIZE_HIGH`（双池懒加载）
+- FLV 读侧：`READ_STREAM_BYTES_POOL_SIZE_HIGH`（双池懒加载）
+- HLS 读侧：不走 bytes pool；按 `qn` 选择不同 channel depth（避免额外 copy）
+
+设计特点：
+
+- 1080p 及以下继续使用默认池（`*_BYTES_POOL_SIZE`）。
+- 高画质池采用懒加载：只有出现高画质任务才初始化。
+- 当高画质任务长期为空时，高画质池会释放引用（`= nil`），交由 GC 后续回收。
+- `*_CHAN_BUFFER_SIZE` 不区分 high 版本，继续沿用现有长度配置。
 
 > [!NOTE]
 > `PERF_PRESET` 只新增行为分支，不会覆盖你手动配置的数值型环境变量（例如 `LIVE_STREAM_WRITER_*`、`READ_STREAM_*`）。

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Android 模式下会先注入一组移动端默认值（如 `HOST=127.0.0.1`、`
 | `STREAM_WRITER_BUFFER_SIZE` | 流写入器（写入文件）缓冲区大小（字节） | `1048576` (1 MB) |
 | `READ_STREAM_BYTES_POOL_SIZE` | 读取直播流时使用的字节池单块大小（字节）；`FLV` / `HLS` 共用，建议与常见 chunk 大小一致 | `524288` (512 KB) |
 | `READ_STREAM_CHAN_BUFFER_SIZE` | 读取直播流时的通道缓冲区大小（chunk 数）；更大值可容忍网络/写入短时抖动，但会增加在途内存 | `16` |
+| `PERF_PRESET` | 性能行为预设：`low-cpu`（默认，偏向更低 CPU）/ `low-mem`（偏向更低内存平台） | `low-cpu` |
 | `LIVE_STREAM_WRITER_BUFFER_SIZE` | 实时流写入缓冲区（用于直播录制或实时下载，字节）；更大的值减少 flush 频率，降低 SD 卡磨损 | `8388608` (8 MB) |
 | `LIVE_STREAM_WRITER_SYNC_PERIOD_SECS` | 实时流写入器执行周期性 `sync` 的周期（秒）；设为 0 禁用周期性 sync（仅在 Close 时 sync），大幅减少 SD 卡磨损 | `0` |
 | `LIVE_STREAM_WRITER_FLUSH_PERIOD_SECS` | 实时流写入器执行周期性 `flush` 的周期（秒）；值越大 flush 频率越低，越有利于减少 SD 卡写入频次 | `10` |
@@ -297,6 +298,29 @@ Android 模式下会先注入一组移动端默认值（如 `HOST=127.0.0.1`、`
 | `SKIP_SMALL_FLUSH` | 启用 microSD 磨损保护：在达到 `SKIP_SMALL_FLUSH_THRESHOLD` 之前仅缓存内存，不创建文件 | `true` |
 | `SEQUENTIAL_WRITE` | 启用全局 flush 锁以序列化多路录制的写入操作；仅在多路并发录制写入同一物理磁盘时建议启用，可显著降低 I/O 峰值 | `true` |
 | `MIN_DISK_SPACE_BYTES` | 录制所需的最小磁盘空间（字节），低于此值将拒绝新录制任务 | `5368709120` (5 GB) |
+
+### PERF_PRESET 行为预设
+
+`PERF_PRESET` 是“行为开关”，用于在不改变现有数值型环境变量语义的前提下，快速切换系统偏好：
+
+- `low-cpu`（默认）：偏向降低 CPU 抖动，沿用当前高复用路径。
+- `low-mem`：偏向降低内存常驻平台，牺牲部分峰值吞吐余量。
+
+当前版本的主要行为差异：
+
+- **writer pool 行为**  
+  - `low-cpu`：使用 bucketed bytes pool（更激进复用，减少分配/GC 抖动）。  
+  - `low-mem`：使用更保守的 bytes slice pool 固定容量策略（降低 bucket 常驻占用）。
+- **HLS prefetch worker**  
+  - `low-cpu`：`4`  
+  - `low-mem`：`2`  
+  - 在 `low-mem` 下，若进入恢复失败阶段，会临时降到 `1`，恢复后自动回到 preset 对应值。
+- **启动日志**  
+  - 启动时会输出当前性能预设，便于线上排查（例如：`性能预设：low-mem`）。
+
+> [!NOTE]
+> `PERF_PRESET` 只新增行为分支，不会覆盖你手动配置的数值型环境变量（例如 `LIVE_STREAM_WRITER_*`、`READ_STREAM_*`）。
+> 若你需要做精细调参，仍建议先确定 `PERF_PRESET`，再按设备特性调整具体数值。
 
 #### FRP 内网穿透配置说明
 

--- a/internal/modules/config/config.go
+++ b/internal/modules/config/config.go
@@ -79,21 +79,23 @@ type Config struct {
 	FFmpegAllowDuringRecordingMaxActiveRecordings int
 
 	// configurable performances
-	ReadStreamBytesPoolSize  int
-	ReadStreamChanBufferSize int
+	ReadStreamBytesPoolSize     int
+	ReadStreamChanBufferSize    int
+	readStreamBytesPoolSizeHigh int
 
 	// configurable global performances
-	uploadBufferSize               int
-	downloadBufferSize             int
-	streamWriterBufferSize         int
-	liveStreamWriterBufferSize     int
-	liveStreamWriterSyncPeriod     int
-	liveStreamWriterFlushPeriod    int
-	liveStreamWriterChanBufferSize int
-	liveStreamWriterBytesPoolSize  int
-	skipSmallFlushThreshold        int
-	skipSmallFlush                 bool
-	sequentialWrite                bool
+	uploadBufferSize                  int
+	downloadBufferSize                int
+	streamWriterBufferSize            int
+	liveStreamWriterBufferSize        int
+	liveStreamWriterSyncPeriod        int
+	liveStreamWriterFlushPeriod       int
+	liveStreamWriterChanBufferSize    int
+	liveStreamWriterBytesPoolSize     int
+	liveStreamWriterBytesPoolSizeHigh int
+	skipSmallFlushThreshold           int
+	skipSmallFlush                    bool
+	sequentialWrite                   bool
 }
 
 var logger = logrus.WithField("module", "config")
@@ -185,21 +187,23 @@ func provider(lc fx.Lifecycle) (*Config, error) {
 		FFmpegAllowDuringRecordingMaxActiveRecordings: utils.MustAtoi(ffmpegAllowDuringRecordingMaxActives), // <1 = no limit; when >=1, ffmpeg during recording runs only if active recordings <= this value
 
 		// stream performance configs
-		ReadStreamBytesPoolSize:  utils.MustAtoi(utils.EmptyOrElse(os.Getenv("READ_STREAM_BYTES_POOL_SIZE"), "524288")), // default 512KB
-		ReadStreamChanBufferSize: utils.MustAtoi(utils.EmptyOrElse(os.Getenv("READ_STREAM_CHAN_BUFFER_SIZE"), "16")),    // default 16
+		ReadStreamBytesPoolSize:     utils.MustAtoi(utils.EmptyOrElse(os.Getenv("READ_STREAM_BYTES_POOL_SIZE"), "524288")),       // default 512KB
+		ReadStreamChanBufferSize:    utils.MustAtoi(utils.EmptyOrElse(os.Getenv("READ_STREAM_CHAN_BUFFER_SIZE"), "16")),          // default 16
+		readStreamBytesPoolSizeHigh: utils.MustAtoi(utils.EmptyOrElse(os.Getenv("READ_STREAM_BYTES_POOL_SIZE_HIGH"), "1048576")), // default 1MB for 2K/4K
 
 		// global performance configs
-		uploadBufferSize:               utils.MustAtoi(utils.EmptyOrElse(os.Getenv("UPLOAD_BUFFER_SIZE"), "5242880")),                // default 5MB
-		downloadBufferSize:             utils.MustAtoi(utils.EmptyOrElse(os.Getenv("DOWNLOAD_BUFFER_SIZE"), "5242880")),              // default 5MB
-		streamWriterBufferSize:         utils.MustAtoi(utils.EmptyOrElse(os.Getenv("STREAM_WRITER_BUFFER_SIZE"), "1048576")),         // default 1MB
-		liveStreamWriterBufferSize:     utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_BUFFER_SIZE"), "8388608")),    // 8MB: prioritize lower flush frequency for SD card longevity
-		liveStreamWriterSyncPeriod:     utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_SYNC_PERIOD_SECS"), "0")),     // 0 = disabled; sync only on Close() to minimize SD card wear
-		liveStreamWriterFlushPeriod:    utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_FLUSH_PERIOD_SECS"), "10")),   // default 10s: fewer flush operations, lower SD card wear
-		liveStreamWriterChanBufferSize: utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_CHAN_BUFFER_SIZE"), "64")),    // default 64: limits in-flight memory while still tolerating write latency bursts
-		liveStreamWriterBytesPoolSize:  utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_BYTES_POOL_SIZE"), "524288")), // 512KB per buffer
-		skipSmallFlushThreshold:        utils.MustAtoi(utils.EmptyOrElse(os.Getenv("SKIP_SMALL_FLUSH_THRESHOLD"), "1048576")),        // default 1MB: delay file creation until buffered bytes reach this threshold
-		skipSmallFlush:                 os.Getenv("SKIP_SMALL_FLUSH") != "false",                                                     // enabled by default; when true, SD-card protection mode is enabled
-		sequentialWrite:                os.Getenv("SEQUENTIAL_WRITE") != "false",                                                     // enabled by default; set false to disable global flush serialization
+		uploadBufferSize:                  utils.MustAtoi(utils.EmptyOrElse(os.Getenv("UPLOAD_BUFFER_SIZE"), "5242880")),                      // default 5MB
+		downloadBufferSize:                utils.MustAtoi(utils.EmptyOrElse(os.Getenv("DOWNLOAD_BUFFER_SIZE"), "5242880")),                    // default 5MB
+		streamWriterBufferSize:            utils.MustAtoi(utils.EmptyOrElse(os.Getenv("STREAM_WRITER_BUFFER_SIZE"), "1048576")),               // default 1MB
+		liveStreamWriterBufferSize:        utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_BUFFER_SIZE"), "8388608")),          // 8MB: prioritize lower flush frequency for SD card longevity
+		liveStreamWriterSyncPeriod:        utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_SYNC_PERIOD_SECS"), "0")),           // 0 = disabled; sync only on Close() to minimize SD card wear
+		liveStreamWriterFlushPeriod:       utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_FLUSH_PERIOD_SECS"), "10")),         // default 10s: fewer flush operations, lower SD card wear
+		liveStreamWriterChanBufferSize:    utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_CHAN_BUFFER_SIZE"), "64")),          // default 64: limits in-flight memory while still tolerating write latency bursts
+		liveStreamWriterBytesPoolSize:     utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_BYTES_POOL_SIZE"), "524288")),       // 512KB per buffer
+		liveStreamWriterBytesPoolSizeHigh: utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_BYTES_POOL_SIZE_HIGH"), "1048576")), // default 1MB for 2K/4K
+		skipSmallFlushThreshold:           utils.MustAtoi(utils.EmptyOrElse(os.Getenv("SKIP_SMALL_FLUSH_THRESHOLD"), "1048576")),              // default 1MB: delay file creation until buffered bytes reach this threshold
+		skipSmallFlush:                    os.Getenv("SKIP_SMALL_FLUSH") != "false",                                                           // enabled by default; when true, SD-card protection mode is enabled
+		sequentialWrite:                   os.Getenv("SEQUENTIAL_WRITE") != "false",                                                           // enabled by default; set false to disable global flush serialization
 	}
 
 	ReadOnly = &GlobalReadOnly{config: c}

--- a/internal/modules/config/config.go
+++ b/internal/modules/config/config.go
@@ -67,6 +67,8 @@ type Config struct {
 	ProductionMode  bool
 	SilentAccessLog bool
 
+	perfPreset string
+
 	MinDiskSpaceBytes int64
 
 	CloudConvertCheckIntervalSecs                 int
@@ -173,6 +175,7 @@ func provider(lc fx.Lifecycle) (*Config, error) {
 		Debug:                              debug,
 		ProductionMode:                     os.Getenv("PRODUCTION_MODE") == "true",
 		SilentAccessLog:                    os.Getenv("SILENT_ACCESS_LOG") == "true",
+		perfPreset:                         strings.ToLower(strings.TrimSpace(utils.EmptyOrElse(os.Getenv("PERF_PRESET"), perfPresetLowCPU))),
 		MinDiskSpaceBytes:                  utils.MustAtoi64(utils.EmptyOrElse(os.Getenv("MIN_DISK_SPACE_BYTES"), "5368709120")), // 5GB
 		CloudConvertCheckIntervalSecs:      utils.MustAtoi(utils.EmptyOrElse(os.Getenv("CLOUDCONVERT_CHECK_INTERVAL_SECS"), "180")),
 		CloudConvertMaxConcurrentDownloads: utils.MustAtoi(utils.EmptyOrElse(os.Getenv("CLOUDCONVERT_MAX_CONCURRENT_DOWNLOADS"), "1")),
@@ -186,17 +189,17 @@ func provider(lc fx.Lifecycle) (*Config, error) {
 		ReadStreamChanBufferSize: utils.MustAtoi(utils.EmptyOrElse(os.Getenv("READ_STREAM_CHAN_BUFFER_SIZE"), "16")),    // default 16
 
 		// global performance configs
-		uploadBufferSize:               utils.MustAtoi(utils.EmptyOrElse(os.Getenv("UPLOAD_BUFFER_SIZE"), "5242880")),                         // default 5MB
-		downloadBufferSize:             utils.MustAtoi(utils.EmptyOrElse(os.Getenv("DOWNLOAD_BUFFER_SIZE"), "5242880")),                       // default 5MB
-		streamWriterBufferSize:         utils.MustAtoi(utils.EmptyOrElse(os.Getenv("STREAM_WRITER_BUFFER_SIZE"), "1048576")),                  // default 1MB
-		liveStreamWriterBufferSize:     utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_BUFFER_SIZE"), "8388608")),             // 8MB: prioritize lower flush frequency for SD card longevity
-		liveStreamWriterSyncPeriod:     utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_SYNC_PERIOD_SECS"), "0")),              // 0 = disabled; sync only on Close() to minimize SD card wear
-		liveStreamWriterFlushPeriod:    utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_FLUSH_PERIOD_SECS"), "10")),            // default 10s: fewer flush operations, lower SD card wear
-		liveStreamWriterChanBufferSize: utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_CHAN_BUFFER_SIZE"), "64")),             // default 64: limits in-flight memory while still tolerating write latency bursts
-		liveStreamWriterBytesPoolSize:  utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_BYTES_POOL_SIZE"), "524288")),          // 512KB per buffer
+		uploadBufferSize:               utils.MustAtoi(utils.EmptyOrElse(os.Getenv("UPLOAD_BUFFER_SIZE"), "5242880")),                // default 5MB
+		downloadBufferSize:             utils.MustAtoi(utils.EmptyOrElse(os.Getenv("DOWNLOAD_BUFFER_SIZE"), "5242880")),              // default 5MB
+		streamWriterBufferSize:         utils.MustAtoi(utils.EmptyOrElse(os.Getenv("STREAM_WRITER_BUFFER_SIZE"), "1048576")),         // default 1MB
+		liveStreamWriterBufferSize:     utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_BUFFER_SIZE"), "8388608")),    // 8MB: prioritize lower flush frequency for SD card longevity
+		liveStreamWriterSyncPeriod:     utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_SYNC_PERIOD_SECS"), "0")),     // 0 = disabled; sync only on Close() to minimize SD card wear
+		liveStreamWriterFlushPeriod:    utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_FLUSH_PERIOD_SECS"), "10")),   // default 10s: fewer flush operations, lower SD card wear
+		liveStreamWriterChanBufferSize: utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_CHAN_BUFFER_SIZE"), "64")),    // default 64: limits in-flight memory while still tolerating write latency bursts
+		liveStreamWriterBytesPoolSize:  utils.MustAtoi(utils.EmptyOrElse(os.Getenv("LIVE_STREAM_WRITER_BYTES_POOL_SIZE"), "524288")), // 512KB per buffer
 		skipSmallFlushThreshold:        utils.MustAtoi(utils.EmptyOrElse(os.Getenv("SKIP_SMALL_FLUSH_THRESHOLD"), "1048576")),        // default 1MB: delay file creation until buffered bytes reach this threshold
-		skipSmallFlush:                 os.Getenv("SKIP_SMALL_FLUSH") != "false",                                                              // enabled by default; when true, SD-card protection mode is enabled
-		sequentialWrite:                os.Getenv("SEQUENTIAL_WRITE") != "false",                                                              // enabled by default; set false to disable global flush serialization
+		skipSmallFlush:                 os.Getenv("SKIP_SMALL_FLUSH") != "false",                                                     // enabled by default; when true, SD-card protection mode is enabled
+		sequentialWrite:                os.Getenv("SEQUENTIAL_WRITE") != "false",                                                     // enabled by default; set false to disable global flush serialization
 	}
 
 	ReadOnly = &GlobalReadOnly{config: c}
@@ -205,6 +208,7 @@ func provider(lc fx.Lifecycle) (*Config, error) {
 		if err := ReadOnly.Validate(); err != nil {
 			return err
 		}
+		logger.Infof("性能预设：%s", ReadOnly.PerfPreset())
 		if err := os.MkdirAll(c.OutputDir, 0755); err != nil {
 			return err
 		}

--- a/internal/modules/config/global.go
+++ b/internal/modules/config/global.go
@@ -5,11 +5,13 @@ import "fmt"
 var ReadOnly *GlobalReadOnly = nil
 
 const (
+	perfPresetLowCPU = "low-cpu"
+	perfPresetLowMem = "low-mem"
+
 	defaultCloudConvertCheckIntervalSecs                 = 180
 	defaultCloudConvertMaxConcurrentDownloads            = 1
 	defaultFFmpegCheckIntervalSecs                       = 60
 	defaultFFmpegMaxConcurrentTasks                      = 1
-	defaultFFmpegAllowDuringRecordingMaxActiveRecordings = 1
 	defaultLiveStreamWriterSyncPeriodSecs                = 0 // Disable periodic sync to reduce SD card wear; data syncs only on Close()
 	defaultLiveStreamWriterFlushPeriodSecs               = 15
 	defaultLiveStreamWriterChanBufferSize                = 64
@@ -20,6 +22,30 @@ const (
 // for global readonly access
 type GlobalReadOnly struct {
 	config *Config
+}
+
+func (g *GlobalReadOnly) PerfPreset() string {
+	switch g.config.perfPreset {
+	case perfPresetLowMem:
+		return perfPresetLowMem
+	default:
+		return perfPresetLowCPU
+	}
+}
+
+func (g *GlobalReadOnly) IsLowMemPreset() bool {
+	return g.PerfPreset() == perfPresetLowMem
+}
+
+func (g *GlobalReadOnly) IsLowCPUPreset() bool {
+	return g.PerfPreset() == perfPresetLowCPU
+}
+
+func (g *GlobalReadOnly) HlsSegmentFetchWorkers() int {
+	if g.IsLowMemPreset() {
+		return 2
+	}
+	return 4
 }
 
 func (g *GlobalReadOnly) UploadBufferSize() int {
@@ -157,6 +183,11 @@ func (g *GlobalReadOnly) Validate() error {
 	}
 	if g.config.skipSmallFlushThreshold <= 0 {
 		logger.Warnf("SKIP_SMALL_FLUSH_THRESHOLD 无效（%d），使用默认值 %d 字节", g.config.skipSmallFlushThreshold, defaultSkipSmallFlushThreshold)
+	}
+	switch g.config.perfPreset {
+	case "", perfPresetLowCPU, perfPresetLowMem:
+	default:
+		return fmt.Errorf("配置无效：PERF_PRESET 仅支持 %s、%s，当前值：%s", perfPresetLowCPU, perfPresetLowMem, g.config.perfPreset)
 	}
 	// Reject protocol-mismatch configs between FRP backend mode and Fiber listener mode.
 	if g.config.ServerCrt != "" && g.config.ServerKey != "" && g.config.FRPEnabled && !g.config.FRPHttps {

--- a/internal/modules/config/global.go
+++ b/internal/modules/config/global.go
@@ -1,4 +1,4 @@
-﻿package config
+package config
 
 import "fmt"
 
@@ -8,15 +8,17 @@ const (
 	perfPresetLowCPU = "low-cpu"
 	perfPresetLowMem = "low-mem"
 
-	defaultCloudConvertCheckIntervalSecs                 = 180
-	defaultCloudConvertMaxConcurrentDownloads            = 1
-	defaultFFmpegCheckIntervalSecs                       = 60
-	defaultFFmpegMaxConcurrentTasks                      = 1
-	defaultLiveStreamWriterSyncPeriodSecs                = 0 // Disable periodic sync to reduce SD card wear; data syncs only on Close()
-	defaultLiveStreamWriterFlushPeriodSecs               = 15
-	defaultLiveStreamWriterChanBufferSize                = 64
-	defaultLiveStreamWriterBytesPoolSize                 = 512 * 1024 // 512KB per buffer
-	defaultSkipSmallFlushThreshold                       = 1 * 1024 * 1024
+	defaultCloudConvertCheckIntervalSecs      = 180
+	defaultCloudConvertMaxConcurrentDownloads = 1
+	defaultFFmpegCheckIntervalSecs            = 60
+	defaultFFmpegMaxConcurrentTasks           = 1
+	defaultLiveStreamWriterSyncPeriodSecs     = 0 // Disable periodic sync to reduce SD card wear; data syncs only on Close()
+	defaultLiveStreamWriterFlushPeriodSecs    = 15
+	defaultLiveStreamWriterChanBufferSize     = 64
+	defaultLiveStreamWriterBytesPoolSize      = 512 * 1024 // 512KB per buffer
+	defaultReadStreamBytesPoolSizeHigh        = 1024 * 1024
+	defaultLiveStreamWriterBytesPoolSizeHigh  = 1024 * 1024
+	defaultSkipSmallFlushThreshold            = 1 * 1024 * 1024
 )
 
 // for global readonly access
@@ -90,6 +92,24 @@ func (g *GlobalReadOnly) LiveStreamWriterBytesPoolSize() int {
 		return defaultLiveStreamWriterBytesPoolSize
 	}
 	return g.config.liveStreamWriterBytesPoolSize
+}
+
+func (g *GlobalReadOnly) ReadStreamBytesPoolSizeHigh() int {
+	if g.config.readStreamBytesPoolSizeHigh <= 0 {
+		return defaultReadStreamBytesPoolSizeHigh
+	}
+	return g.config.readStreamBytesPoolSizeHigh
+}
+
+func (g *GlobalReadOnly) LiveStreamWriterBytesPoolSizeHigh() int {
+	if g.config.liveStreamWriterBytesPoolSizeHigh <= 0 {
+		return defaultLiveStreamWriterBytesPoolSizeHigh
+	}
+	return g.config.liveStreamWriterBytesPoolSizeHigh
+}
+
+func IsHighQualityQn(qn int) bool {
+	return qn >= 20000
 }
 
 func (g *GlobalReadOnly) SkipSmallFlushThreshold() int {
@@ -183,6 +203,12 @@ func (g *GlobalReadOnly) Validate() error {
 	}
 	if g.config.skipSmallFlushThreshold <= 0 {
 		logger.Warnf("SKIP_SMALL_FLUSH_THRESHOLD 无效（%d），使用默认值 %d 字节", g.config.skipSmallFlushThreshold, defaultSkipSmallFlushThreshold)
+	}
+	if g.config.readStreamBytesPoolSizeHigh <= 0 {
+		logger.Warnf("READ_STREAM_BYTES_POOL_SIZE_HIGH 无效（%d），使用默认值 %d 字节", g.config.readStreamBytesPoolSizeHigh, defaultReadStreamBytesPoolSizeHigh)
+	}
+	if g.config.liveStreamWriterBytesPoolSizeHigh <= 0 {
+		logger.Warnf("LIVE_STREAM_WRITER_BYTES_POOL_SIZE_HIGH 无效（%d），使用默认值 %d 字节", g.config.liveStreamWriterBytesPoolSizeHigh, defaultLiveStreamWriterBytesPoolSizeHigh)
 	}
 	switch g.config.perfPreset {
 	case "", perfPresetLowCPU, perfPresetLowMem:

--- a/internal/modules/config/perf_preset_test.go
+++ b/internal/modules/config/perf_preset_test.go
@@ -1,0 +1,48 @@
+package config
+
+import "testing"
+
+func TestPerfPreset_DefaultsToLowCPU(t *testing.T) {
+	g := &GlobalReadOnly{config: &Config{perfPreset: ""}}
+
+	if g.PerfPreset() != perfPresetLowCPU {
+		t.Fatalf("expected default perf preset %q, got %q", perfPresetLowCPU, g.PerfPreset())
+	}
+	if !g.IsLowCPUPreset() {
+		t.Fatal("expected IsLowCPUPreset to be true")
+	}
+	if g.IsLowMemPreset() {
+		t.Fatal("expected IsLowMemPreset to be false")
+	}
+	if got := g.HlsSegmentFetchWorkers(); got != 4 {
+		t.Fatalf("expected hls workers 4 for low-cpu, got %d", got)
+	}
+}
+
+func TestPerfPreset_LowMemWorkers(t *testing.T) {
+	g := &GlobalReadOnly{config: &Config{perfPreset: perfPresetLowMem}}
+
+	if g.PerfPreset() != perfPresetLowMem {
+		t.Fatalf("expected perf preset %q, got %q", perfPresetLowMem, g.PerfPreset())
+	}
+	if g.IsLowCPUPreset() {
+		t.Fatal("expected IsLowCPUPreset to be false")
+	}
+	if !g.IsLowMemPreset() {
+		t.Fatal("expected IsLowMemPreset to be true")
+	}
+	if got := g.HlsSegmentFetchWorkers(); got != 2 {
+		t.Fatalf("expected hls workers 2 for low-mem, got %d", got)
+	}
+}
+
+func TestValidateRejectsInvalidPerfPreset(t *testing.T) {
+	g := &GlobalReadOnly{config: &Config{
+		BilibiliLoginMode: "controller",
+		perfPreset:        "fastest",
+	}}
+
+	if err := g.Validate(); err == nil {
+		t.Fatal("expected Validate to reject invalid PERF_PRESET")
+	}
+}

--- a/internal/modules/config/perf_preset_test.go
+++ b/internal/modules/config/perf_preset_test.go
@@ -46,3 +46,36 @@ func TestValidateRejectsInvalidPerfPreset(t *testing.T) {
 		t.Fatal("expected Validate to reject invalid PERF_PRESET")
 	}
 }
+
+func TestHighPoolSizeAccessorsFallbackAndOverride(t *testing.T) {
+	g := &GlobalReadOnly{config: &Config{}}
+	if got := g.ReadStreamBytesPoolSizeHigh(); got != defaultReadStreamBytesPoolSizeHigh {
+		t.Fatalf("expected read high default %d, got %d", defaultReadStreamBytesPoolSizeHigh, got)
+	}
+	if got := g.LiveStreamWriterBytesPoolSizeHigh(); got != defaultLiveStreamWriterBytesPoolSizeHigh {
+		t.Fatalf("expected writer high default %d, got %d", defaultLiveStreamWriterBytesPoolSizeHigh, got)
+	}
+
+	g = &GlobalReadOnly{config: &Config{
+		readStreamBytesPoolSizeHigh:       2 * 1024 * 1024,
+		liveStreamWriterBytesPoolSizeHigh: 1536 * 1024,
+	}}
+	if got := g.ReadStreamBytesPoolSizeHigh(); got != 2*1024*1024 {
+		t.Fatalf("expected read high override 2MB, got %d", got)
+	}
+	if got := g.LiveStreamWriterBytesPoolSizeHigh(); got != 1536*1024 {
+		t.Fatalf("expected writer high override 1536KB, got %d", got)
+	}
+}
+
+func TestIsHighQualityQn(t *testing.T) {
+	if IsHighQualityQn(10000) {
+		t.Fatal("expected qn=10000 not high quality")
+	}
+	if !IsHighQualityQn(20000) {
+		t.Fatal("expected qn=20000 to be high quality")
+	}
+	if !IsHighQualityQn(30000) {
+		t.Fatal("expected qn=30000 to be high quality")
+	}
+}

--- a/internal/processors/buffered_stream_writer.go
+++ b/internal/processors/buffered_stream_writer.go
@@ -68,9 +68,9 @@ type BufferedStreamWriterProcessor struct {
 
 	// bytesPool is used to reduce allocations when copying incoming data.
 	// When nil, fallback to direct allocation via make().
-	bytesPool     *pool.BucketedBytesPool
-	pendingChunks [][]byte
-	pendingBytes  int
+	bytesPool   pool.ByteSlicePool
+	pendingBuf  []byte
+	pendingSize int
 
 	lastCreateFileFailureLog time.Time
 	suppressedCreateFailures int
@@ -125,8 +125,8 @@ func (w *BufferedStreamWriterProcessor) Open(ctx context.Context, log *logrus.En
 		w.file.Store(file)
 		w.writer = rw.NewFlushLockedBufferedWriter(file, w.bufferSize, flushLocker)
 	} else {
-		w.pendingChunks = make([][]byte, 0, 16)
-		w.pendingBytes = 0
+		w.pendingBuf = make([]byte, 0, w.skipSmallFlushThreshold)
+		w.pendingSize = 0
 	}
 
 	w.logger = log.WithField("file", w.path)
@@ -174,8 +174,8 @@ func (w *BufferedStreamWriterProcessor) Close() error {
 
 	if w.sdcardProtection && w.file.Load() == nil {
 		threshold := w.skipSmallFlushThreshold
-		w.logger.Warnf("未创建文件且总写入字节数（%d）小于保护阈值（%d），直接丢弃内存中的数据", w.bytesWritten+int64(w.pendingBytes), threshold)
-		w.releasePendingChunks()
+		w.logger.Warnf("未创建文件且总写入字节数（%d）小于保护阈值（%d），直接丢弃内存中的数据", w.bytesWritten+int64(w.pendingSize), threshold)
+		w.releasePendingBuffer()
 		return nil
 	}
 
@@ -214,19 +214,19 @@ func (w *BufferedStreamWriterProcessor) writePeriodically() {
 
 			if w.sdcardProtection && w.file.Load() == nil {
 				threshold := w.skipSmallFlushThreshold
-				w.pendingChunks = append(w.pendingChunks, data)
-				w.pendingBytes += len(data)
-				if w.pendingBytes < threshold {
+				w.pendingBuf = append(w.pendingBuf, data...)
+				w.pendingSize += len(data)
+				w.bytesPool.Put(data)
+				if w.pendingSize < threshold {
 					continue
 				}
 				// Buffer threshold reached; create file and flush pending data.
 				if err := w.createFileAndWriter(); err != nil {
-					if w.pendingBytes <= maxPendingBytesBeforeDrop {
+					if w.pendingSize <= maxPendingBytesBeforeDrop {
 						if w.shouldLogCreateFileFailure() {
 							w.logger.Warnf(
-								"创建文件失败，暂不丢弃待写数据：pending=%dB chunks=%d limit=%dB suppressed=%d err=%v",
-								w.pendingBytes,
-								len(w.pendingChunks),
+								"创建文件失败，暂不丢弃待写数据：pending=%dB limit=%dB suppressed=%d err=%v",
+								w.pendingSize,
 								maxPendingBytesBeforeDrop,
 								w.suppressedCreateFailures,
 								err,
@@ -242,31 +242,26 @@ func (w *BufferedStreamWriterProcessor) writePeriodically() {
 						w.suppressedCreateFailures = 0
 					}
 					w.logger.Warnf(
-						"创建文件失败且待写数据超过硬阈值，丢弃待写数据以防止内存持续增长：dropped=%dB chunks=%d limit=%dB err=%v",
-						w.pendingBytes,
-						len(w.pendingChunks),
+						"创建文件失败且待写数据超过硬阈值，丢弃待写数据以防止内存持续增长：dropped=%dB limit=%dB err=%v",
+						w.pendingSize,
 						maxPendingBytesBeforeDrop,
 						err,
 					)
-					w.releasePendingChunks()
+					w.releasePendingBuffer()
 					continue
 				}
 				// Reset throttling state after file creation recovers.
 				w.lastCreateFileFailureLog = time.Time{}
 				w.suppressedCreateFailures = 0
-				for _, chunk := range w.pendingChunks {
-					n, err := w.writer.Write(chunk)
-					if n != len(chunk) {
-						w.logger.Warnf("写入待缓存数据长度不完整：%d/%d", n, len(chunk))
-					}
-					if err != nil {
-						w.logger.Warnf("写入待缓存数据失败：%v", err)
-					}
-					w.bytesWritten += int64(n)
-					w.bytesPool.Put(chunk)
+				n, err := w.writer.Write(w.pendingBuf)
+				if n != len(w.pendingBuf) {
+					w.logger.Warnf("写入待缓存数据长度不完整：%d/%d", n, len(w.pendingBuf))
 				}
-				w.pendingChunks = w.pendingChunks[:0]
-				w.pendingBytes = 0
+				if err != nil {
+					w.logger.Warnf("写入待缓存数据失败：%v", err)
+				}
+				w.bytesWritten += int64(n)
+				w.releasePendingBuffer()
 				continue
 			}
 
@@ -415,24 +410,21 @@ func WithChanBufferSize(size int) BufferedStreamWriterOptions {
 	}
 }
 
-// WithBytesPool configures a bucketed bytes pool to reuse buffers during copying,
-// reducing GC pressure. Buckets are typically computed from
-// LIVE_STREAM_WRITER_BYTES_POOL_SIZE and include several nearby sizes.
+// WithBytesPool configures a byte-slice pool for copy buffer reuse, reducing GC
+// pressure. Implementations can be bucketed (low-cpu) or single-cap/limited
+// (low-mem) based on runtime strategy.
 //
 //	pool := pool.NewBucketedBytesPool(512 * 1024)
 //	writer := NewBufferedStreamWriter(path, WithBytesPool(pool))
-func WithBytesPool(bp *pool.BucketedBytesPool) BufferedStreamWriterOptions {
+func WithBytesPool(bp pool.ByteSlicePool) BufferedStreamWriterOptions {
 	return func(p *BufferedStreamWriterProcessor) {
 		p.bytesPool = bp
 	}
 }
 
-func (w *BufferedStreamWriterProcessor) releasePendingChunks() {
-	for _, chunk := range w.pendingChunks {
-		w.bytesPool.Put(chunk)
-	}
-	w.pendingChunks = nil
-	w.pendingBytes = 0
+func (w *BufferedStreamWriterProcessor) releasePendingBuffer() {
+	w.pendingBuf = nil
+	w.pendingSize = 0
 }
 
 func (w *BufferedStreamWriterProcessor) shouldLogCreateFileFailure() bool {

--- a/internal/record_strategies/flv.go
+++ b/internal/record_strategies/flv.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bilirec/bilirec/internal/processors"
 	"github.com/bilirec/bilirec/pkg/flv"
 	"github.com/bilirec/bilirec/pkg/pipeline"
+	"github.com/bilirec/bilirec/pkg/pool"
 )
 
 const (
@@ -19,12 +20,17 @@ const (
 // FlvStrategy handles HTTP-FLV byte streams.
 // It is a zero-invasion extraction of the logic previously inlined in rotate().
 type FlvStrategy struct {
-	sharedFixer *flv.RealtimeFixer
+	sharedFixer       *flv.RealtimeFixer
+	writerPool        pool.ByteSlicePool
+	releaseWriterPool func()
 }
 
-func NewFlvStrategy() *FlvStrategy {
+func NewFlvStrategy(qn int) *FlvStrategy {
+	writerPool, releaseWriterPool := acquireWriterPool(qn)
 	return &FlvStrategy{
-		sharedFixer: flv.NewRealtimeFixer(),
+		sharedFixer:       flv.NewRealtimeFixer(),
+		writerPool:        writerPool,
+		releaseWriterPool: releaseWriterPool,
 	}
 }
 
@@ -45,7 +51,7 @@ func (s *FlvStrategy) BuildPipeline(ctx context.Context, outputPath string, stat
 			processors.WithSyncPeriod(time.Duration(config.ReadOnly.LiveStreamWriterSyncPeriodSecs())*time.Second),
 			processors.WithFlushPeriod(time.Duration(config.ReadOnly.LiveStreamWriterFlushPeriodSecs())*time.Second),
 			processors.WithChanBufferSize(config.ReadOnly.LiveStreamWriterChanBufferSize()),
-			processors.WithBytesPool(getWriterBytesPool()),
+			processors.WithBytesPool(s.writerPool),
 			processors.WithSDCardProtection(config.ReadOnly.SkipSmallFlush()),
 			processors.WithSequentialWrite(config.ReadOnly.SequentialWrite()),
 		),
@@ -78,6 +84,10 @@ func (s *FlvStrategy) HandleErr(err error) ErrHandleResult {
 }
 
 func (s *FlvStrategy) Close() error {
+	if s.releaseWriterPool != nil {
+		s.releaseWriterPool()
+		s.releaseWriterPool = nil
+	}
 	s.sharedFixer.Close()
 	return nil
 }

--- a/internal/record_strategies/flv_benchmark_test.go
+++ b/internal/record_strategies/flv_benchmark_test.go
@@ -22,7 +22,7 @@ func makeFLVStreamChunk() []byte {
 func BenchmarkFlvStrategy_PipelineWriterThroughput(b *testing.B) {
 	ensureBenchmarkConfig()
 	ctx := context.Background()
-	strategy := NewFlvStrategy()
+	strategy := NewFlvStrategy(10000)
 	outputPath := filepath.Join(b.TempDir(), "bench.flv")
 	pipe, err := strategy.BuildPipeline(ctx, outputPath, &RotationState{Data: map[string][]byte{}})
 	if err != nil {

--- a/internal/record_strategies/hls_fmp4.go
+++ b/internal/record_strategies/hls_fmp4.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bilirec/bilirec/internal/modules/config"
 	"github.com/bilirec/bilirec/internal/processors"
 	"github.com/bilirec/bilirec/pkg/pipeline"
+	"github.com/bilirec/bilirec/pkg/pool"
 )
 
 // HlsFmp4Strategy handles HLS fragmented MP4 byte streams.
@@ -18,12 +19,17 @@ import (
 // Appending all segments in order produces a valid fragmented MP4 source file
 // (.fmp4), which can then be remuxed to seek-friendly .mp4 in finalize flow.
 type HlsFmp4Strategy struct {
-	bases map[uint32]uint64
+	bases             map[uint32]uint64
+	writerPool        pool.ByteSlicePool
+	releaseWriterPool func()
 }
 
-func NewHlsFmp4Strategy() *HlsFmp4Strategy {
+func NewHlsFmp4Strategy(qn int) *HlsFmp4Strategy {
+	writerPool, releaseWriterPool := acquireWriterPool(qn)
 	return &HlsFmp4Strategy{
-		bases: make(map[uint32]uint64),
+		bases:             make(map[uint32]uint64),
+		writerPool:        writerPool,
+		releaseWriterPool: releaseWriterPool,
 	}
 }
 
@@ -41,7 +47,7 @@ func (s *HlsFmp4Strategy) BuildPipeline(ctx context.Context, outputPath string, 
 			processors.WithSyncPeriod(time.Duration(config.ReadOnly.LiveStreamWriterSyncPeriodSecs())*time.Second),
 			processors.WithFlushPeriod(time.Duration(config.ReadOnly.LiveStreamWriterFlushPeriodSecs())*time.Second),
 			processors.WithChanBufferSize(config.ReadOnly.LiveStreamWriterChanBufferSize()),
-			processors.WithBytesPool(getWriterBytesPool()),
+			processors.WithBytesPool(s.writerPool),
 			processors.WithSDCardProtection(config.ReadOnly.SkipSmallFlush()),
 			processors.WithSequentialWrite(config.ReadOnly.SequentialWrite()),
 		),
@@ -62,4 +68,10 @@ func (s *HlsFmp4Strategy) HandleErr(err error) ErrHandleResult {
 	return ErrHandleResult{Action: ErrActionAbort}
 }
 
-func (s *HlsFmp4Strategy) Close() error { return nil }
+func (s *HlsFmp4Strategy) Close() error {
+	if s.releaseWriterPool != nil {
+		s.releaseWriterPool()
+		s.releaseWriterPool = nil
+	}
+	return nil
+}

--- a/internal/record_strategies/hls_fmp4_benchmark_test.go
+++ b/internal/record_strategies/hls_fmp4_benchmark_test.go
@@ -36,7 +36,7 @@ func makeFmp4Fragment(trackID uint32, decodeTime uint64) []byte {
 func BenchmarkHlsFmp4Strategy_PipelineThroughput(b *testing.B) {
 	ensureBenchmarkConfig()
 	ctx := context.Background()
-	strategy := NewHlsFmp4Strategy()
+	strategy := NewHlsFmp4Strategy(10000)
 	outputPath := filepath.Join(b.TempDir(), "bench.fmp4")
 	pipe, err := strategy.BuildPipeline(ctx, outputPath, &RotationState{Data: map[string][]byte{}})
 	if err != nil {

--- a/internal/record_strategies/hls_ts.go
+++ b/internal/record_strategies/hls_ts.go
@@ -7,16 +7,23 @@ import (
 	"github.com/bilirec/bilirec/internal/modules/config"
 	"github.com/bilirec/bilirec/internal/processors"
 	"github.com/bilirec/bilirec/pkg/pipeline"
+	"github.com/bilirec/bilirec/pkg/pool"
 )
 
 // HlsTsStrategy handles HLS MPEG-TS byte streams.
 // Each []byte received from ReadHlsStream is a complete .ts segment.
 // Conversion to .mp4 is handled by the recorder's finalize() like FLV.
 type HlsTsStrategy struct {
+	writerPool        pool.ByteSlicePool
+	releaseWriterPool func()
 }
 
-func NewHlsTsStrategy() *HlsTsStrategy {
-	return &HlsTsStrategy{}
+func NewHlsTsStrategy(qn int) *HlsTsStrategy {
+	writerPool, releaseWriterPool := acquireWriterPool(qn)
+	return &HlsTsStrategy{
+		writerPool:        writerPool,
+		releaseWriterPool: releaseWriterPool,
+	}
 
 }
 
@@ -33,7 +40,7 @@ func (s *HlsTsStrategy) BuildPipeline(ctx context.Context, outputPath string, st
 			processors.WithSyncPeriod(time.Duration(config.ReadOnly.LiveStreamWriterSyncPeriodSecs())*time.Second),
 			processors.WithFlushPeriod(time.Duration(config.ReadOnly.LiveStreamWriterFlushPeriodSecs())*time.Second),
 			processors.WithChanBufferSize(config.ReadOnly.LiveStreamWriterChanBufferSize()),
-			processors.WithBytesPool(getWriterBytesPool()),
+			processors.WithBytesPool(s.writerPool),
 			processors.WithSDCardProtection(config.ReadOnly.SkipSmallFlush()),
 			processors.WithSequentialWrite(config.ReadOnly.SequentialWrite()),
 		),
@@ -45,4 +52,10 @@ func (s *HlsTsStrategy) HandleErr(err error) ErrHandleResult {
 	return ErrHandleResult{Action: ErrActionAbort}
 }
 
-func (s *HlsTsStrategy) Close() error { return nil }
+func (s *HlsTsStrategy) Close() error {
+	if s.releaseWriterPool != nil {
+		s.releaseWriterPool()
+		s.releaseWriterPool = nil
+	}
+	return nil
+}

--- a/internal/record_strategies/hls_ts_benchmark_test.go
+++ b/internal/record_strategies/hls_ts_benchmark_test.go
@@ -31,7 +31,7 @@ func makeBenchmarkTSSegment(packetCount int) []byte {
 func BenchmarkHlsTsStrategy_PipelineThroughput(b *testing.B) {
 	ensureBenchmarkConfig()
 	ctx := context.Background()
-	strategy := NewHlsTsStrategy()
+	strategy := NewHlsTsStrategy(10000)
 	outputPath := filepath.Join(b.TempDir(), "bench.ts")
 	pipe, err := strategy.BuildPipeline(ctx, outputPath, &RotationState{Data: map[string][]byte{}})
 	if err != nil {

--- a/internal/record_strategies/strategy.go
+++ b/internal/record_strategies/strategy.go
@@ -57,20 +57,29 @@ type StreamRecordStrategy interface {
 }
 
 var (
-	initPoolOnce    sync.Once
-	writerBytesPool pool.ByteSlicePool
+	writerPoolOnce sync.Once
+	writerPools    *pool.LazyDualPool[pool.ByteSlicePool]
 )
 
-// getWriterBytesPool returns the writer bytes pool, initializing it on first call
-func getWriterBytesPool() pool.ByteSlicePool {
-	initPoolOnce.Do(func() {
-		baseSize := config.ReadOnly.LiveStreamWriterBytesPoolSize()
-		if config.ReadOnly.IsLowMemPreset() {
-			// low-mem keeps a single-cap pool to reduce bucketed long-tail retention.
-			writerBytesPool = pool.NewBytesSlicePool(baseSize, baseSize)
-			return
-		}
-		writerBytesPool = pool.NewBucketedBytesPool(baseSize)
+func newWriterPool(size int) pool.ByteSlicePool {
+	if config.ReadOnly.IsLowMemPreset() {
+		// low-mem keeps a single-cap pool to reduce bucketed long-tail retention.
+		return pool.NewBytesSlicePool(size, size)
+	}
+	return pool.NewBucketedBytesPool(size)
+}
+
+func getWriterPools() *pool.LazyDualPool[pool.ByteSlicePool] {
+	writerPoolOnce.Do(func() {
+		writerPools = pool.NewLazyDualPool(
+			15*time.Minute,
+			func() pool.ByteSlicePool { return newWriterPool(config.ReadOnly.LiveStreamWriterBytesPoolSize()) },
+			func() pool.ByteSlicePool { return newWriterPool(config.ReadOnly.LiveStreamWriterBytesPoolSizeHigh()) },
+		)
 	})
-	return writerBytesPool
+	return writerPools
+}
+
+func acquireWriterPool(qn int) (pool.ByteSlicePool, func()) {
+	return getWriterPools().Acquire(config.IsHighQualityQn(qn))
 }

--- a/internal/record_strategies/strategy.go
+++ b/internal/record_strategies/strategy.go
@@ -58,13 +58,19 @@ type StreamRecordStrategy interface {
 
 var (
 	initPoolOnce    sync.Once
-	writerBytesPool *pool.BucketedBytesPool
+	writerBytesPool pool.ByteSlicePool
 )
 
 // getWriterBytesPool returns the writer bytes pool, initializing it on first call
-func getWriterBytesPool() *pool.BucketedBytesPool {
+func getWriterBytesPool() pool.ByteSlicePool {
 	initPoolOnce.Do(func() {
-		writerBytesPool = pool.NewBucketedBytesPool(config.ReadOnly.LiveStreamWriterBytesPoolSize())
+		baseSize := config.ReadOnly.LiveStreamWriterBytesPoolSize()
+		if config.ReadOnly.IsLowMemPreset() {
+			// low-mem keeps a single-cap pool to reduce bucketed long-tail retention.
+			writerBytesPool = pool.NewBytesSlicePool(baseSize, baseSize)
+			return
+		}
+		writerBytesPool = pool.NewBucketedBytesPool(baseSize)
 	})
 	return writerBytesPool
 }

--- a/internal/services/recorder/recorder.go
+++ b/internal/services/recorder/recorder.go
@@ -271,7 +271,7 @@ func (r *Service) Start(roomId int, options ...RecordStartOption) error {
 				return "", nil
 			}
 
-			hlsCh, hlsErr := r.st.ReadHlsStream(fetchM3u8URL, r.bilic.GetLiveHlsPlaylistClient(), r.bilic.GetLiveHlsSegmentClient(), ctx)
+			hlsCh, hlsErr := r.st.ReadHlsStream(fetchM3u8URL, r.bilic.GetLiveHlsPlaylistClient(), r.bilic.GetLiveHlsSegmentClient(), ctx, streamInfo.Qn)
 			if hlsErr != nil {
 				l.Errorf("cannot start HLS stream: %v, will try next url", hlsErr)
 				continue
@@ -279,8 +279,8 @@ func (r *Service) Start(roomId int, options ...RecordStartOption) error {
 			ch = hlsCh
 			strategy = utils.TernaryFunc(
 				streamInfo.Format == "ts",
-				func() rs.StreamRecordStrategy { return rs.NewHlsTsStrategy() },
-				func() rs.StreamRecordStrategy { return rs.NewHlsFmp4Strategy() },
+				func() rs.StreamRecordStrategy { return rs.NewHlsTsStrategy(streamInfo.Qn) },
+				func() rs.StreamRecordStrategy { return rs.NewHlsFmp4Strategy(streamInfo.Qn) },
 			)
 		default: // "flv" and any unknown format
 			startTimeFlv := time.Now()
@@ -328,13 +328,13 @@ func (r *Service) Start(roomId int, options ...RecordStartOption) error {
 				utils.TruncateString(finalURL, 160),
 			)
 
-			flvCh, flvErr := r.st.ReadFlvStream(resp, ctx)
+			flvCh, flvErr := r.st.ReadFlvStream(resp, ctx, streamInfo.Qn)
 			if flvErr != nil {
 				l.Errorf("cannot capture url stream: %v, will try next url", flvErr)
 				continue
 			}
 			ch = flvCh
-			strategy = rs.NewFlvStrategy()
+			strategy = rs.NewFlvStrategy(streamInfo.Qn)
 		}
 
 		// Resolve runtime max duration for recorder internals.

--- a/internal/services/stream/flv.go
+++ b/internal/services/stream/flv.go
@@ -1,47 +1,50 @@
-﻿package stream
+package stream
 
 import (
 	"context"
 	"io"
 	"time"
 
+	"github.com/bilirec/bilirec/pkg/pool"
 	"github.com/go-resty/resty/v2"
 )
 
-func (r *Service) ReadFlvStream(resp *resty.Response, ctx context.Context) (<-chan []byte, error) {
+func (r *Service) ReadFlvStream(resp *resty.Response, ctx context.Context, qn int) (<-chan []byte, error) {
+	bytesPool, releasePool := r.acquireReadPool(qn)
 	ch := make(chan []byte, r.chanBufferSize)
-	go r.read(ch, resp.RawBody(), ctx)
+	go r.read(ch, resp.RawBody(), ctx, bytesPool, releasePool)
 	return ch, nil
 }
 
-func (r *Service) read(ch chan<- []byte, stream io.ReadCloser, ctx context.Context) {
+func (r *Service) read(ch chan<- []byte, stream io.ReadCloser, ctx context.Context, bytesPool *pool.BytesPool, releasePool func()) {
 	defer stream.Close()
 	defer close(ch)
+	defer releasePool()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		default:
-			buf := r.pool.GetBytes()
+			buf := bytesPool.GetBytes()
 			n, err := stream.Read(buf)
 			if err == io.EOF {
 				logger.Info("直播流已结束")
-				r.Flush(buf)
+				r.FlushTo(bytesPool, buf)
 				return
 			} else if err != nil {
 				logger.Errorf("读取直播流失败：%v", err)
-				r.Flush(buf)
+				r.FlushTo(bytesPool, buf)
 				return
 			}
 			if n > 0 {
 				select {
 				case ch <- buf[:n]:
 				case <-ctx.Done():
-					r.Flush(buf)
+					r.FlushTo(bytesPool, buf)
 					return
 				}
 			} else {
-				r.Flush(buf)
+				r.FlushTo(bytesPool, buf)
 				time.Sleep(1 * time.Millisecond)
 			}
 		}

--- a/internal/services/stream/flv_pool_tier_test.go
+++ b/internal/services/stream/flv_pool_tier_test.go
@@ -1,0 +1,201 @@
+package stream
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/bilirec/bilirec/pkg/benchreport"
+	"github.com/bilirec/bilirec/pkg/pool"
+	"github.com/sirupsen/logrus"
+)
+
+func TestFlvRead_4KPayload_DefaultVsHighPool(t *testing.T) {
+	const (
+		payloadSize = 900 * 1024 // 900KB: larger than default 512KB, smaller than high 1MB
+		defaultSize = 512 * 1024
+		highSize    = 1024 * 1024
+	)
+
+	newSvc := func() *Service {
+		return &Service{
+			readPools: pool.NewLazyDualPool(
+				15*time.Minute,
+				func() *pool.BytesPool { return pool.NewBytesPool(defaultSize) },
+				func() *pool.BytesPool { return pool.NewBytesPool(highSize) },
+			),
+			chanBufferSize:     64,
+			highChanBufferSize: 64,
+		}
+	}
+
+	run := func(svc *Service, qn int) (chunks int, totalBytes int) {
+		readPool, release := svc.acquireReadPool(qn)
+		defer release()
+
+		ch := make(chan []byte, 8)
+		ctx := context.Background()
+		stream := io.NopCloser(bytes.NewReader(make([]byte, payloadSize)))
+		go svc.read(ch, stream, ctx, readPool, func() {})
+
+		for chunk := range ch {
+			chunks++
+			totalBytes += len(chunk)
+			svc.FlushTo(readPool, chunk)
+		}
+		return chunks, totalBytes
+	}
+
+	defaultChunks, defaultBytes := run(newSvc(), 10000)
+	highChunks, highBytes := run(newSvc(), 20000)
+
+	if defaultBytes != payloadSize {
+		t.Fatalf("default pool total bytes mismatch: got %d, want %d", defaultBytes, payloadSize)
+	}
+	if highBytes != payloadSize {
+		t.Fatalf("high pool total bytes mismatch: got %d, want %d", highBytes, payloadSize)
+	}
+
+	// default 512KB can't hold a 900KB payload in one read, should split.
+	if defaultChunks <= 1 {
+		t.Fatalf("expected default pool to split payload into multiple chunks, got %d", defaultChunks)
+	}
+	// high 1MB can hold 900KB payload in one read.
+	if highChunks != 1 {
+		t.Fatalf("expected high pool to read payload in one chunk, got %d", highChunks)
+	}
+}
+
+func BenchmarkFlvRead_4KPayload_DefaultVsHighPool(b *testing.B) {
+	const (
+		payloadSize = 900 * 1024 // 900KB: >512KB(default), <1MB(high)
+		defaultSize = 512 * 1024
+		highSize    = 1024 * 1024
+	)
+
+	logrus.SetLevel(logrus.WarnLevel)
+	defer logrus.SetLevel(logrus.InfoLevel)
+
+	newSvc := func() *Service {
+		return &Service{
+			readPools: pool.NewLazyDualPool(
+				15*time.Minute,
+				func() *pool.BytesPool { return pool.NewBytesPool(defaultSize) },
+				func() *pool.BytesPool { return pool.NewBytesPool(highSize) },
+			),
+			chanBufferSize:     64,
+			highChanBufferSize: 64,
+		}
+	}
+
+	runOnce := func(svc *Service, qn int) (chunks int, totalBytes int) {
+		readPool, release := svc.acquireReadPool(qn)
+		defer release()
+
+		ch := make(chan []byte, 8)
+		ctx := context.Background()
+		stream := io.NopCloser(bytes.NewReader(make([]byte, payloadSize)))
+		go svc.read(ch, stream, ctx, readPool, func() {})
+
+		for chunk := range ch {
+			chunks++
+			totalBytes += len(chunk)
+			svc.FlushTo(readPool, chunk)
+		}
+		return chunks, totalBytes
+	}
+
+	type perfResult struct {
+		avgChunks float64
+		usPerOp   float64
+		mbPerSec  float64
+		valid     bool
+	}
+	var normalRes perfResult
+	var highRes perfResult
+
+	b.Cleanup(func() {
+		if !normalRes.valid || !highRes.valid {
+			return
+		}
+		chunkReductionPct := (normalRes.avgChunks - highRes.avgChunks) / normalRes.avgChunks * 100.0
+		latencyImprovePct := (normalRes.usPerOp - highRes.usPerOp) / normalRes.usPerOp * 100.0
+		throughputImprovePct := (highRes.mbPerSec - normalRes.mbPerSec) / normalRes.mbPerSec * 100.0
+		b.Logf("📊 4K pool comparison (900KB payload):")
+		b.Logf("  normal(512KB): chunks/op=%.2f, us/op=%.2f, throughput=%.2f MB/s", normalRes.avgChunks, normalRes.usPerOp, normalRes.mbPerSec)
+		b.Logf("  high(1MB):     chunks/op=%.2f, us/op=%.2f, throughput=%.2f MB/s", highRes.avgChunks, highRes.usPerOp, highRes.mbPerSec)
+		b.Logf("  delta: chunk reduction=%.2f%%, latency improvement=%.2f%%, throughput improvement=%.2f%%", chunkReductionPct, latencyImprovePct, throughputImprovePct)
+	})
+
+	b.Run("normal_pool_512KB", func(b *testing.B) {
+		svc := newSvc()
+		mon := benchreport.Start(b, payloadSize)
+		b.ReportAllocs()
+		b.SetBytes(payloadSize)
+		b.ResetTimer()
+		start := time.Now()
+		mon.MarkTimerStart()
+		var totalChunks int64
+		for i := 0; i < b.N; i++ {
+			chunks, total := runOnce(svc, 10000)
+			if total != payloadSize {
+				b.Fatalf("unexpected total bytes: got %d want %d", total, payloadSize)
+			}
+			if chunks <= 1 {
+				b.Fatalf("expected chunk split under normal pool, got chunks=%d", chunks)
+			}
+			totalChunks += int64(chunks)
+			mon.SamplePeriodically(i)
+		}
+		elapsed := time.Since(start)
+		avgChunks := float64(totalChunks) / float64(b.N)
+		b.ReportMetric(avgChunks, "chunks/op")
+		b.ReportMetric((avgChunks-1.0)*100.0, "chunk_overhead_pct")
+		normalRes = perfResult{
+			avgChunks: avgChunks,
+			usPerOp:   float64(elapsed.Microseconds()) / float64(b.N),
+			mbPerSec:  float64(payloadSize*b.N) / elapsed.Seconds() / (1024 * 1024),
+			valid:     true,
+		}
+		b.Cleanup(func() {
+			b.Logf("📊 normal pool summary: avgChunks=%.2f (payload=900KB, pool=512KB)", avgChunks)
+		})
+	})
+
+	b.Run("high_pool_1MB", func(b *testing.B) {
+		svc := newSvc()
+		mon := benchreport.Start(b, payloadSize)
+		b.ReportAllocs()
+		b.SetBytes(payloadSize)
+		b.ResetTimer()
+		start := time.Now()
+		mon.MarkTimerStart()
+		var totalChunks int64
+		for i := 0; i < b.N; i++ {
+			chunks, total := runOnce(svc, 20000)
+			if total != payloadSize {
+				b.Fatalf("unexpected total bytes: got %d want %d", total, payloadSize)
+			}
+			if chunks != 1 {
+				b.Fatalf("expected single chunk under high pool, got chunks=%d", chunks)
+			}
+			totalChunks += int64(chunks)
+			mon.SamplePeriodically(i)
+		}
+		elapsed := time.Since(start)
+		avgChunks := float64(totalChunks) / float64(b.N)
+		b.ReportMetric(avgChunks, "chunks/op")
+		b.ReportMetric((avgChunks-1.0)*100.0, "chunk_overhead_pct")
+		highRes = perfResult{
+			avgChunks: avgChunks,
+			usPerOp:   float64(elapsed.Microseconds()) / float64(b.N),
+			mbPerSec:  float64(payloadSize*b.N) / elapsed.Seconds() / (1024 * 1024),
+			valid:     true,
+		}
+		b.Cleanup(func() {
+			b.Logf("📊 high pool summary: avgChunks=%.2f (payload=900KB, pool=1MB)", avgChunks)
+		})
+	})
+}

--- a/internal/services/stream/hls.go
+++ b/internal/services/stream/hls.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bilirec/bilirec/internal/modules/config"
 	hlsutil "github.com/bilirec/bilirec/pkg/hls"
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"
@@ -32,8 +33,22 @@ var (
 	segmentRetryAttempts  = 3
 	manifestSyncWaitRate  = 0.10
 	segmentPrefetchAhead  = 2
-	segmentFetchWorkers   = 4
 )
+
+func desiredPrefetchWorkersForState(baseWorkers int, lowMem bool, consecutiveFailures int) int {
+	if lowMem && consecutiveFailures > 0 {
+		return 1
+	}
+	return baseWorkers
+}
+
+func resolvePrefetchPolicy() (baseWorkers int, lowMem bool) {
+	// Keep stream path safe even in unusual bootstrap/test contexts.
+	if config.ReadOnly == nil {
+		return 4, false
+	}
+	return config.ReadOnly.HlsSegmentFetchWorkers(), config.ReadOnly.IsLowMemPreset()
+}
 
 type playlistStatusError struct {
 	status int
@@ -95,6 +110,7 @@ func (r *Service) ReadHlsStream(fetchM3u8URL func() (string, error), playlistCli
 		lastEtag       string
 		lastModified   string
 		cachedPlaylist *hlsPlaylist
+		prefetchWorkers int
 	)
 
 	refreshM3u8URL := func(reason string) error {
@@ -118,7 +134,8 @@ func (r *Service) ReadHlsStream(fetchM3u8URL func() (string, error), playlistCli
 
 		m3u8URL = nextURL
 		resolver = nextResolver
-		prefetcher = hlsutil.NewSegmentPrefetcher(ctx, segmentClient, resolver, segmentRetryAttempts, segmentRetryDelay, segmentFetchWorkers)
+		prefetcher = nil
+		prefetchWorkers = 0
 		currentMapURI = ""
 		mapSent = false
 		lastEtag = ""
@@ -280,6 +297,9 @@ func (r *Service) ReadHlsStream(fetchM3u8URL func() (string, error), playlistCli
 					}
 					consecutivePlaylistFailures++
 					logger.Warnf("hls：拉取/解析播放列表失败（第 %d 次）：%v", consecutivePlaylistFailures, err)
+					// Drop prefetcher references aggressively on failure boundaries.
+					prefetcher = nil
+					prefetchWorkers = 0
 
 					// Retry once immediately to reduce the chance of missing short HLS windows.
 					pl, err = fetchPlaylistWithRefresh()
@@ -293,6 +313,8 @@ func (r *Service) ReadHlsStream(fetchM3u8URL func() (string, error), playlistCli
 						}
 						consecutivePlaylistFailures++
 						logger.Warnf("hls：立即重试播放列表失败（第 %d 次）：%v", consecutivePlaylistFailures, err)
+						prefetcher = nil
+						prefetchWorkers = 0
 						if consecutivePlaylistFailures >= 3 {
 							logger.Warnf("hls：播放列表连续失败次数达到 %d", consecutivePlaylistFailures)
 							return
@@ -359,6 +381,21 @@ func (r *Service) ReadHlsStream(fetchM3u8URL func() (string, error), playlistCli
 						}
 						return
 					}
+				}
+				baseWorkers, lowMem := resolvePrefetchPolicy()
+				desiredPrefetchWorkers := desiredPrefetchWorkersForState(baseWorkers, lowMem, consecutivePlaylistFailures)
+				if prefetcher == nil || prefetchWorkers != desiredPrefetchWorkers {
+					if prefetchWorkers > 0 && prefetchWorkers != desiredPrefetchWorkers {
+						logger.Infof("hls：预取并发已从 %d 调整为 %d", prefetchWorkers, desiredPrefetchWorkers)
+					}
+					prefetcher = hlsutil.NewSegmentPrefetcher(ctx, segmentClient, resolver, segmentRetryAttempts, segmentRetryDelay, desiredPrefetchWorkers)
+					prefetchWorkers = desiredPrefetchWorkers
+				}
+				// Defensive: make sure downstream Start/Wait never touches a nil prefetcher.
+				if prefetcher == nil {
+					logger.Warnf("hls：prefetcher 为空，回退重建（workers=%d）", desiredPrefetchWorkers)
+					prefetcher = hlsutil.NewSegmentPrefetcher(ctx, segmentClient, resolver, segmentRetryAttempts, segmentRetryDelay, desiredPrefetchWorkers)
+					prefetchWorkers = desiredPrefetchWorkers
 				}
 				maxSeqInWindow := baseSeq + int64(len(segs)) - 1
 				if nextSeq <= maxSeqInWindow {

--- a/internal/services/stream/hls.go
+++ b/internal/services/stream/hls.go
@@ -100,16 +100,16 @@ func isRetryablePlaylistFetchErr(err error) bool {
 //
 // playlistClient should have a short timeout for m3u8 fetches.
 // segmentClient should have a longer timeout for segment and map downloads.
-func (r *Service) ReadHlsStream(fetchM3u8URL func() (string, error), playlistClient, segmentClient *resty.Client, ctx context.Context) (<-chan []byte, error) {
+func (r *Service) ReadHlsStream(fetchM3u8URL func() (string, error), playlistClient, segmentClient *resty.Client, ctx context.Context, qn int) (<-chan []byte, error) {
 	var (
-		m3u8URL        string
-		resolver       *hlsutil.URLResolver
-		prefetcher     *hlsutil.SegmentPrefetcher
-		currentMapURI  string
-		mapSent        bool
-		lastEtag       string
-		lastModified   string
-		cachedPlaylist *hlsPlaylist
+		m3u8URL         string
+		resolver        *hlsutil.URLResolver
+		prefetcher      *hlsutil.SegmentPrefetcher
+		currentMapURI   string
+		mapSent         bool
+		lastEtag        string
+		lastModified    string
+		cachedPlaylist  *hlsPlaylist
 		prefetchWorkers int
 	)
 
@@ -263,7 +263,7 @@ func (r *Service) ReadHlsStream(fetchM3u8URL func() (string, error), playlistCli
 	currentMapURI = pl.MapURI
 	mapSent = false
 
-	ch := make(chan []byte, r.chanBufferSize)
+	ch := make(chan []byte, r.chanBufferSizeForQn(qn))
 	go func() {
 		defer close(ch)
 		ticker := time.NewTicker(pollInterval)
@@ -437,7 +437,6 @@ func (r *Service) ReadHlsStream(fetchM3u8URL func() (string, error), playlistCli
 							continue
 						}
 						logger.Debugf("hls: map fetch ok bytes=%d elapsed=%v", len(mapResp.Body()), time.Since(mapFetchStart))
-
 						select {
 						case ch <- mapResp.Body():
 							mapSent = true
@@ -469,7 +468,6 @@ func (r *Service) ReadHlsStream(fetchM3u8URL func() (string, error), playlistCli
 					}
 
 					nextSeq = segSeq + 1
-
 					select {
 					case ch <- data:
 					case <-ctx.Done():

--- a/internal/services/stream/hls_benchmark_test.go
+++ b/internal/services/stream/hls_benchmark_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/bilirec/bilirec/pkg/benchreport"
+	"github.com/bilirec/bilirec/pkg/pool"
 	"github.com/go-resty/resty/v2"
 )
 
@@ -49,7 +50,15 @@ func BenchmarkReadHlsStream_DeliveryLatency(b *testing.B) {
 	}))
 	defer server.Close()
 
-	svc := &Service{chanBufferSize: 64}
+	svc := &Service{
+		readPools: pool.NewLazyDualPool(
+			15*time.Minute,
+			func() *pool.BytesPool { return pool.NewBytesPool(512 * 1024) },
+			func() *pool.BytesPool { return pool.NewBytesPool(1024 * 1024) },
+		),
+		chanBufferSize:     64,
+		highChanBufferSize: 64,
+	}
 	playlistClient := resty.New().SetTimeout(3 * time.Second)
 	segmentClient := resty.New().SetTimeout(5 * time.Second)
 	fetchURL := func() (string, error) { return server.URL + playlistPath, nil }
@@ -63,7 +72,7 @@ func BenchmarkReadHlsStream_DeliveryLatency(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ctx, cancel := context.WithCancel(context.Background())
 		start := time.Now()
-		ch, err := svc.ReadHlsStream(fetchURL, playlistClient, segmentClient, ctx)
+		ch, err := svc.ReadHlsStream(fetchURL, playlistClient, segmentClient, ctx, 10000)
 		if err != nil {
 			cancel()
 			b.Fatalf("ReadHlsStream failed: %v", err)

--- a/internal/services/stream/hls_preset_test.go
+++ b/internal/services/stream/hls_preset_test.go
@@ -1,0 +1,45 @@
+package stream
+
+import "testing"
+
+func TestDesiredPrefetchWorkersForState(t *testing.T) {
+	tests := []struct {
+		name                string
+		baseWorkers         int
+		lowMem              bool
+		consecutiveFailures int
+		want                int
+	}{
+		{
+			name:                "low-cpu keeps base",
+			baseWorkers:         4,
+			lowMem:              false,
+			consecutiveFailures: 3,
+			want:                4,
+		},
+		{
+			name:                "low-mem normal keeps base",
+			baseWorkers:         2,
+			lowMem:              true,
+			consecutiveFailures: 0,
+			want:                2,
+		},
+		{
+			name:                "low-mem degrades on failure",
+			baseWorkers:         2,
+			lowMem:              true,
+			consecutiveFailures: 1,
+			want:                1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := desiredPrefetchWorkersForState(tc.baseWorkers, tc.lowMem, tc.consecutiveFailures)
+			if got != tc.want {
+				t.Fatalf("expected workers=%d, got %d", tc.want, got)
+			}
+		})
+	}
+}
+

--- a/internal/services/stream/stream.go
+++ b/internal/services/stream/stream.go
@@ -1,6 +1,8 @@
 package stream
 
 import (
+	"time"
+
 	"github.com/bilirec/bilirec/internal/modules/config"
 	"github.com/bilirec/bilirec/pkg/pool"
 	"github.com/sirupsen/logrus"
@@ -9,19 +11,51 @@ import (
 var logger = logrus.WithField("service", "stream")
 
 type Service struct {
-	pool           *pool.BytesPool
-	chanBufferSize int
+	readPools          *pool.LazyDualPool[*pool.BytesPool]
+	chanBufferSize     int
+	highChanBufferSize int
 }
 
 func NewService(cfg *config.Config) *Service {
+	highChanBufferSize := cfg.ReadStreamChanBufferSize
+	if highChanBufferSize < 48 {
+		highChanBufferSize = 48
+	}
 	return &Service{
-		pool:           pool.NewBytesPool(cfg.ReadStreamBytesPoolSize),
-		chanBufferSize: cfg.ReadStreamChanBufferSize,
+		readPools: pool.NewLazyDualPool(
+			15*time.Minute,
+			func() *pool.BytesPool { return pool.NewBytesPool(cfg.ReadStreamBytesPoolSize) },
+			func() *pool.BytesPool { return pool.NewBytesPool(config.ReadOnly.ReadStreamBytesPoolSizeHigh()) },
+		),
+		chanBufferSize:     cfg.ReadStreamChanBufferSize,
+		highChanBufferSize: highChanBufferSize,
 	}
 }
 
 func (r *Service) Flush(buf []byte) {
-	if cap(buf) == r.pool.BufferSize {
-		r.pool.PutBytes(buf)
+	r.FlushTo(r.readPools.Default(), buf)
+	highPool := r.readPools.MaybeHigh()
+	if highPool != nil {
+		r.FlushTo(highPool, buf)
 	}
+}
+
+func (r *Service) FlushTo(p *pool.BytesPool, buf []byte) {
+	if p == nil || buf == nil {
+		return
+	}
+	if cap(buf) == p.BufferSize {
+		p.PutBytes(buf)
+	}
+}
+
+func (r *Service) acquireReadPool(qn int) (*pool.BytesPool, func()) {
+	return r.readPools.Acquire(config.IsHighQualityQn(qn))
+}
+
+func (r *Service) chanBufferSizeForQn(qn int) int {
+	if config.IsHighQualityQn(qn) {
+		return r.highChanBufferSize
+	}
+	return r.chanBufferSize
 }

--- a/pkg/flv/realtime_fixer.go
+++ b/pkg/flv/realtime_fixer.go
@@ -225,6 +225,7 @@ func (rf *RealtimeFixer) ResetTimestampStore() {
 	// Rotation segments start with split-detector-injected carried bytes, not a FLV header.
 	rf.isRotationSegment = true
 	rf.sourceHeaderOK = false
+	rf.trimBufferAtBoundary()
 }
 
 // ResetDedupCache clears the deduplication cache, which can be useful when starting a new segment to avoid false positives from old tags.
@@ -236,7 +237,7 @@ func (rf *RealtimeFixer) ResetDedupCache() {
 	if rf.dedupCache != nil {
 		rf.dedupCache.Reset()
 	}
-
+	rf.trimBufferAtBoundary()
 }
 
 func (rf *RealtimeFixer) Close() {
@@ -289,6 +290,24 @@ func (rf *RealtimeFixer) compactBufferIfNeeded() {
 	// Return old to pool (Put only keeps buffers <= maxCap; otherwise allow GC)
 	realtimeBufferPool.Put(old)
 }
+
+func (rf *RealtimeFixer) trimBufferAtBoundary() {
+	if rf.buffer == nil {
+		return
+	}
+	if rf.buffer.Cap() <= 2*DefaultBufferSize {
+		return
+	}
+	newBuf := realtimeBufferPool.Get()
+	newBuf.Reset()
+	if rf.buffer.Len() > 0 {
+		newBuf.Write(rf.buffer.Bytes())
+	}
+	old := rf.buffer
+	rf.buffer = newBuf
+	realtimeBufferPool.Put(old)
+}
+
 func (rf *RealtimeFixer) fixTimestamp(tag *Tag) {
 	ts := rf.tsStore
 	currentTimestamp := tag.Timestamp

--- a/pkg/pool/bucketed_bytes.go
+++ b/pkg/pool/bucketed_bytes.go
@@ -23,6 +23,8 @@ type BucketedBytesPool struct {
 	oversized atomic.Uint64
 }
 
+var _ ByteSlicePool = (*BucketedBytesPool)(nil)
+
 type BucketedBytesPoolStats struct {
 	Hits      uint64
 	Misses    uint64
@@ -47,7 +49,8 @@ func NewBucketedBytesPool(baseSize int) *BucketedBytesPool {
 }
 
 func (p *BucketedBytesPool) GetSized(size int) []byte {
-	if size <= 0 {
+	size = normalizeByteSliceSize(size)
+	if size == 0 {
 		return []byte{}
 	}
 	idx := p.findBucketIndex(size)

--- a/pkg/pool/byte_slice_pool.go
+++ b/pkg/pool/byte_slice_pool.go
@@ -1,0 +1,17 @@
+package pool
+
+// ByteSlicePool defines a shared contract for variable-sized byte slice pools.
+// Implementations may decide their own pooling strategy (single-cap, bucketed,
+// bounded, etc.) as long as they can provide a sized buffer and accept a put-back.
+type ByteSlicePool interface {
+	GetSized(size int) []byte
+	Put(buf []byte)
+}
+
+func normalizeByteSliceSize(size int) int {
+	if size < 0 {
+		return 0
+	}
+	return size
+}
+

--- a/pkg/pool/byte_slice_pool_test.go
+++ b/pkg/pool/byte_slice_pool_test.go
@@ -1,0 +1,73 @@
+package pool
+
+import "testing"
+
+func TestByteSlicePool_GetSized_NormalizesNegative(t *testing.T) {
+	pools := []struct {
+		name string
+		pool ByteSlicePool
+	}{
+		{name: "bucketed", pool: NewBucketedBytesPool(256 * 1024)},
+		{name: "slice", pool: NewBytesSlicePool(256*1024, 256*1024)},
+	}
+
+	for _, tc := range pools {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.pool.GetSized(-1)
+			if len(got) != 0 {
+				t.Fatalf("expected len=0 for negative size, got %d", len(got))
+			}
+			tc.pool.Put(got)
+		})
+	}
+}
+
+func TestByteSlicePool_GetSized_AndPutRoundtrip(t *testing.T) {
+	pools := []struct {
+		name string
+		pool ByteSlicePool
+		size int
+	}{
+		{name: "bucketed_small", pool: NewBucketedBytesPool(256 * 1024), size: 64 * 1024},
+		{name: "bucketed_mid", pool: NewBucketedBytesPool(256 * 1024), size: 256 * 1024},
+		{name: "slice_fixed", pool: NewBytesSlicePool(256*1024, 256*1024), size: 128 * 1024},
+	}
+
+	for _, tc := range pools {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := tc.pool.GetSized(tc.size)
+			if len(buf) != tc.size {
+				t.Fatalf("expected len=%d, got %d", tc.size, len(buf))
+			}
+			tc.pool.Put(buf)
+
+			next := tc.pool.GetSized(tc.size)
+			if len(next) != tc.size {
+				t.Fatalf("expected len=%d after put/get, got %d", tc.size, len(next))
+			}
+			tc.pool.Put(next)
+		})
+	}
+}
+
+func TestByteSlicePool_OversizedRequest(t *testing.T) {
+	pools := []struct {
+		name string
+		pool ByteSlicePool
+	}{
+		{name: "bucketed", pool: NewBucketedBytesPool(256 * 1024)},
+		{name: "slice", pool: NewBytesSlicePool(256*1024, 256*1024)},
+	}
+
+	oversized := 6 * 1024 * 1024
+	for _, tc := range pools {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := tc.pool.GetSized(oversized)
+			if len(buf) != oversized {
+				t.Fatalf("expected oversized len=%d, got %d", oversized, len(buf))
+			}
+			tc.pool.Put(buf) // should be safe even when oversized is not retained
+		})
+	}
+}
+

--- a/pkg/pool/bytes_slice.go
+++ b/pkg/pool/bytes_slice.go
@@ -11,6 +11,8 @@ type BytesSlicePool struct {
 	initCap int
 }
 
+var _ ByteSlicePool = (*BytesSlicePool)(nil)
+
 // NewBytesSlicePool creates a new variable-size bytes slice pool.
 // initCap: initial capacity for newly allocated slices.
 // maxCap: maximum capacity to pool; slices larger than this are discarded (GC'd).
@@ -42,9 +44,7 @@ func (p *BytesSlicePool) Get() []byte {
 // GetSized retrieves a slice and ensures its length is exactly size.
 // If the pooled slice capacity is insufficient, a new slice is allocated.
 func (p *BytesSlicePool) GetSized(size int) []byte {
-	if size < 0 {
-		size = 0
-	}
+	size = normalizeByteSliceSize(size)
 	b := p.Get()
 	if cap(b) < size {
 		p.Put(b)
@@ -57,7 +57,7 @@ func (p *BytesSlicePool) GetSized(size int) []byte {
 // Slices with capacity > maxCap are not pooled (left for GC).
 func (p *BytesSlicePool) Put(b []byte) {
 	if b == nil || cap(b) > p.maxCap {
-        return
-    }
-    p.pool.Put(b[:0])
+		return
+	}
+	p.pool.Put(b[:0])
 }

--- a/pkg/pool/lazy_dual_pool.go
+++ b/pkg/pool/lazy_dual_pool.go
@@ -1,0 +1,109 @@
+package pool
+
+import (
+	"sync"
+	"time"
+)
+
+// LazyDualPool manages a default pool and an optional high-tier pool.
+// The high-tier pool is lazily initialized and released when idle.
+type LazyDualPool[T comparable] struct {
+	mu sync.Mutex
+
+	defaultPool T
+	highPool    T
+
+	highRef      int
+	highLastUsed time.Time
+	idleTTL      time.Duration
+	cleanupTimer *time.Timer
+
+	newDefault func() T
+	newHigh    func() T
+}
+
+func NewLazyDualPool[T comparable](idleTTL time.Duration, newDefault func() T, newHigh func() T) *LazyDualPool[T] {
+	return &LazyDualPool[T]{
+		idleTTL:    idleTTL,
+		newDefault: newDefault,
+		newHigh:    newHigh,
+	}
+}
+
+func (m *LazyDualPool[T]) Default() T {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var zero T
+	if m.defaultPool == zero {
+		m.defaultPool = m.newDefault()
+	}
+	return m.defaultPool
+}
+
+func (m *LazyDualPool[T]) MaybeHigh() T {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.highPool
+}
+
+func (m *LazyDualPool[T]) Acquire(useHigh bool) (T, func()) {
+	if !useHigh {
+		return m.Default(), func() {}
+	}
+
+	m.mu.Lock()
+	m.stopCleanupTimerLocked()
+	var zero T
+	if m.highPool == zero {
+		m.highPool = m.newHigh()
+	}
+	m.highRef++
+	m.highLastUsed = time.Now()
+	hp := m.highPool
+	m.mu.Unlock()
+
+	return hp, func() {
+		m.mu.Lock()
+		if m.highRef > 0 {
+			m.highRef--
+		}
+		m.highLastUsed = time.Now()
+		if m.highRef == 0 {
+			m.scheduleCleanupLocked(m.idleTTL)
+		}
+		m.mu.Unlock()
+	}
+}
+
+func (m *LazyDualPool[T]) TryCleanup(now time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var zero T
+	if m.highPool == zero || m.highRef > 0 || m.highLastUsed.IsZero() {
+		return
+	}
+	elapsed := now.Sub(m.highLastUsed)
+	if elapsed < m.idleTTL {
+		m.scheduleCleanupLocked(m.idleTTL - elapsed)
+		return
+	}
+	m.stopCleanupTimerLocked()
+	m.highPool = zero
+}
+
+func (m *LazyDualPool[T]) stopCleanupTimerLocked() {
+	if m.cleanupTimer != nil {
+		m.cleanupTimer.Stop()
+		m.cleanupTimer = nil
+	}
+}
+
+func (m *LazyDualPool[T]) scheduleCleanupLocked(delay time.Duration) {
+	if delay < 0 {
+		delay = 0
+	}
+	m.stopCleanupTimerLocked()
+	m.cleanupTimer = time.AfterFunc(delay, func() {
+		m.TryCleanup(time.Now())
+	})
+}

--- a/pkg/pool/lazy_dual_pool_test.go
+++ b/pkg/pool/lazy_dual_pool_test.go
@@ -1,0 +1,71 @@
+package pool_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bilirec/bilirec/pkg/pool"
+)
+
+func TestAcquireReadPool_UsesDefaultAndHigh(t *testing.T) {
+	defaultPool := pool.NewBytesPool(512 * 1024)
+	lp := pool.NewLazyDualPool(
+		15*time.Minute,
+		func() *pool.BytesPool { return defaultPool },
+		func() *pool.BytesPool { return pool.NewBytesPool(1024 * 1024) },
+	)
+
+	gotDefault, releaseDefault := lp.Acquire(false)
+	if gotDefault != defaultPool {
+		t.Fatal("expected default quality to use default pool")
+	}
+	releaseDefault()
+
+	highPool, releaseHigh := lp.Acquire(true)
+	if highPool == nil {
+		t.Fatal("expected high quality to initialize high pool")
+	}
+	if highPool == defaultPool {
+		t.Fatal("expected high quality to use dedicated high pool")
+	}
+	if lp.MaybeHigh() == nil {
+		t.Fatal("expected high pool snapshot to be non-nil after acquire")
+	}
+	releaseHigh()
+}
+
+func TestTryCleanupHighPool_ReleasesWhenIdleAndNoRef(t *testing.T) {
+	defaultPool := pool.NewBytesPool(512 * 1024)
+	lp := pool.NewLazyDualPool(
+		1*time.Minute,
+		func() *pool.BytesPool { return defaultPool },
+		func() *pool.BytesPool { return pool.NewBytesPool(1024 * 1024) },
+	)
+
+	_, releaseHigh := lp.Acquire(true)
+	releaseHigh()
+
+	lp.TryCleanup(time.Now().Add(2 * time.Minute))
+	if lp.MaybeHigh() != nil {
+		t.Fatal("expected highPool to be nil after idle timeout cleanup")
+	}
+}
+
+func TestReleaseSchedulesCleanupTimer(t *testing.T) {
+	lp := pool.NewLazyDualPool(
+		20*time.Millisecond,
+		func() *pool.BytesPool { return pool.NewBytesPool(8) },
+		func() *pool.BytesPool { return pool.NewBytesPool(16) },
+	)
+
+	high, release := lp.Acquire(true)
+	if high == nil {
+		t.Fatal("expected high pool to be initialized")
+	}
+	release()
+
+	time.Sleep(40 * time.Millisecond)
+	if got := lp.MaybeHigh(); got != nil {
+		t.Fatal("expected high pool to be nil after scheduled cleanup")
+	}
+}

--- a/scripts/run_all_perf_comparisons.sh
+++ b/scripts/run_all_perf_comparisons.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd /workspace
+
+go install github.com/swaggo/swag/cmd/swag@v1.16.6 2>/dev/null || true
+export PATH="$(go env GOPATH)/bin:$PATH"
+
+echo "=== 1/3 main branch ==="
+git checkout main
+./scripts/run_perf_comparison.sh main-branch main "" || echo "main-branch had failures (continuing)"
+
+echo "=== 2/3 feat/optimize-perf low-cpu ==="
+git checkout feat/optimize-perf
+./scripts/run_perf_comparison.sh low-cpu feat/optimize-perf low-cpu || echo "low-cpu had failures (continuing)"
+
+echo "=== 3/3 feat/optimize-perf low-mem ==="
+./scripts/run_perf_comparison.sh low-mem feat/optimize-perf low-mem || echo "low-mem had failures (continuing)"
+
+echo "ALL DONE" | tee /workspace/bench-results/COMPLETE

--- a/scripts/run_perf_comparison.sh
+++ b/scripts/run_perf_comparison.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Run all benchmarks and memleak tests for a given configuration label.
+set -euo pipefail
+
+LABEL="${1:?usage: run_perf_comparison.sh <label> [branch] [perf_preset]}"
+BRANCH="${2:-$(git branch --show-current)}"
+PRESET="${3:-}"
+OUT_DIR="/workspace/bench-results/${LABEL}"
+mkdir -p "$OUT_DIR"
+
+echo "=== Config: $LABEL (branch=$BRANCH preset=${PRESET:-none}) ===" | tee "$OUT_DIR/meta.txt"
+date -u +"%Y-%m-%dT%H:%M:%SZ" | tee -a "$OUT_DIR/meta.txt"
+git rev-parse HEAD | tee -a "$OUT_DIR/meta.txt"
+git log -1 --oneline | tee -a "$OUT_DIR/meta.txt"
+
+export BILIBILI_LOGIN_MODE=anonymous
+if [[ -n "$PRESET" ]]; then
+  export PERF_PRESET="$PRESET"
+else
+  unset PERF_PRESET || true
+fi
+
+echo "PERF_PRESET=${PERF_PRESET:-<unset>}" | tee -a "$OUT_DIR/meta.txt"
+
+# Swagger/docs required for full module graph (CI setup).
+mkdir -p docs
+if [[ ! -f docs/swagger.json ]]; then
+  echo '{}' > docs/swagger.json
+fi
+if command -v swag >/dev/null 2>&1; then
+  swag init -g internal/modules/rest/rest.go -o docs 2>/dev/null || true
+fi
+
+BENCH_PKGS=(
+  ./internal/processors/...
+  ./internal/record_strategies/...
+  ./internal/services/stream/...
+  ./pkg/hls/...
+  ./pkg/pool/...
+  ./pkg/rw/...
+)
+
+BENCH_ENV=()
+if [[ -n "${PERF_PRESET:-}" ]]; then
+  BENCH_ENV=(env "PERF_PRESET=$PERF_PRESET")
+fi
+
+# --- Benchmarks ---
+echo "[$(date -u +%H:%M:%S)] Running benchmarks..." | tee -a "$OUT_DIR/meta.txt"
+set +e
+"${BENCH_ENV[@]}" go test -v -bench=. -benchmem -run='^$' -timeout 30m "${BENCH_PKGS[@]}" \
+  2>&1 | tee "$OUT_DIR/benchmarks.log"
+BENCH_EXIT=${PIPESTATUS[0]}
+set -e
+echo "benchmark_exit=$BENCH_EXIT" >> "$OUT_DIR/meta.txt"
+
+grep -E '^(Benchmark|PASS|FAIL|ok |---)' "$OUT_DIR/benchmarks.log" > "$OUT_DIR/benchmarks_summary.txt" || true
+grep -E '(📊|Benchmark:|Iterations:|Wall time:|Per op:|Throughput:|Baseline:|Peak during:|After run:|Peak heap sys:|Total alloc:|GC runs:)' \
+  "$OUT_DIR/benchmarks.log" > "$OUT_DIR/benchmarks_reports.txt" || true
+
+# --- Memleak tests ---
+echo "[$(date -u +%H:%M:%S)] Running memleak tests..." | tee -a "$OUT_DIR/meta.txt"
+set +e
+"${BENCH_ENV[@]}" go test -v -count=1 -timeout 2h ./internal/services/recorder \
+  -run 'TestRecorder_MemoryLeak|TestRecorder_Goroutine_Leak' \
+  2>&1 | tee "$OUT_DIR/memleak.log"
+MEM_EXIT=${PIPESTATUS[0]}
+set -e
+echo "memleak_exit=$MEM_EXIT" >> "$OUT_DIR/meta.txt"
+
+grep -E '(^(=== RUN|--- PASS|--- FAIL|--- SKIP|PASS|FAIL|ok )|📊|📈|✅|⚠️|Memory Analysis|Baseline:|During record:|After stop:|After GC:|Cleanup:|retained|goroutine|性能预设)' \
+  "$OUT_DIR/memleak.log" > "$OUT_DIR/memleak_summary.txt" || true
+
+echo "[$(date -u +%H:%M:%S)] Done: $LABEL (bench=$BENCH_EXIT memleak=$MEM_EXIT)" | tee -a "$OUT_DIR/meta.txt"
+exit $(( BENCH_EXIT != 0 || MEM_EXIT != 0 ? 1 : 0 ))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds shell scripts to automate benchmark and memleak test runs across branch/preset configurations.

## Scripts

- `scripts/run_perf_comparison.sh` — runs all benchmark packages and memleak tests for a single config (label, branch, optional `PERF_PRESET`), saving logs under `bench-results/<label>/`
- `scripts/run_all_perf_comparisons.sh` — runs the full three-way comparison: `main`, `feat/optimize-perf` + `low-cpu`, `feat/optimize-perf` + `low-mem`

## Usage

```bash
./scripts/run_all_perf_comparisons.sh
# or individually:
git checkout main
./scripts/run_perf_comparison.sh main-branch main ""
git checkout feat/optimize-perf
./scripts/run_perf_comparison.sh low-cpu feat/optimize-perf low-cpu
./scripts/run_perf_comparison.sh low-mem feat/optimize-perf low-mem
```

Generated results are written to `bench-results/` (not committed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7826accf-8cb7-46b7-a79a-54e795fac281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7826accf-8cb7-46b7-a79a-54e795fac281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

